### PR TITLE
Fix protobuf w/ descriptors + nested collections

### DIFF
--- a/pb/src/main/scala/sauerkraut/format/pb/MacroHelper.scala
+++ b/pb/src/main/scala/sauerkraut/format/pb/MacroHelper.scala
@@ -52,12 +52,11 @@ class MacroHelper(using val qctx: Quotes):
         num.asInstanceOf[Int]
 
   /** Creates a type + name array from tuple-types of ElemLabels + ElemTypes. */
-  def typesAndNames(elems: TypeRepr, labels: TypeRepr): Map[String, TypeRepr] =
+  def typesAndNames(elems: TypeRepr, labels: TypeRepr): Seq[(String, TypeRepr)] =
     (elems, labels) match
       case (TupleCons(elem, nextElems), TupleCons(ConstantString(label), nextLabels)) => 
-        Map("test" -> elem)
-        typesAndNames(nextElems, nextLabels) + (label -> elem)
-      case _ => Map.empty
+        (label -> elem) +: typesAndNames(nextElems, nextLabels)
+      case _ => Seq.empty
 
   /** Extracts the string from any constnat type.  This just toString's the value. */
   object ConstantString:
@@ -65,13 +64,14 @@ class MacroHelper(using val qctx: Quotes):
       t match
         case ConstantType(c) => Some(c.value.toString)
         case _ => None
-  
-  def fieldNamesTypesAndNumber(mirrorProductType: TypeRepr): Map[String, (TypeRepr, Int)] =
+
+  /** Extracts an (idemptotently sorted) list of field names, types and "numbers" (via proto annotations). */
+  def fieldNamesTypesAndNumber(mirrorProductType: TypeRepr): Seq[(String, (TypeRepr, Int))] =
     mirrorProductType.widen match {
       case ProductOfRefinement(elems, labels) =>
         val fields = typesAndNames(elems, labels)
         fields.map {
           case (k,v) => (k, (v, fieldNumberFromType(v)))
         }
-      case None => Map.empty
+      case None => Seq.empty
     }

--- a/pb/src/main/scala/sauerkraut/format/pb/writer.scala
+++ b/pb/src/main/scala/sauerkraut/format/pb/writer.scala
@@ -28,9 +28,12 @@ class ProtocolBufferFieldWriter(
     extends PickleWriter with PickleCollectionWriter:
   // Writing a collection should simple write a field multiple times.
   override def putCollection(length: Int)(work: PickleCollectionWriter => Unit): PickleWriter =
-    // This does NOT work for primitive collections.
-    work(this)
-    this
+    desc match
+      case CollectionTypeDescriptor(_, elementTag) =>
+        work(ProtocolBufferFieldWriter(out, fieldNum, elementTag))
+        this
+      case _ =>
+        throw new RuntimeException(s"Could not find collection descriptor, found: $desc")
   override def putStructure(picklee: Any, tag: FastTypeTag[?])(work: PickleStructureWriter => Unit): PickleWriter =
     desc match
       case msg: MessageProtoDescriptor[_] =>
@@ -42,42 +45,8 @@ class ProtocolBufferFieldWriter(
         work(DescriptorBasedProtoStructureWriter(tmpOut, msg))
         tmpOut.flush()
         out.writeByteArray(fieldNum, tmpByteOut.toByteArray())
-      // TODO - We the following in benchmarks:
-      /* 
-[info] java.lang.RuntimeException: Cannot find structure definition from: CollectionTypeDescriptor(Given(scala.collection.mutable.ArrayBuffer[scala.Long]),PrimitiveTypeDescriptor(LongTag))
-[info]  at sauerkraut.format.pb.ProtocolBufferFieldWriter.putStructure(writer.scala:44)
-[info]  at sauerkraut.benchmarks.SimpleMessage$$anon$1.write(BenchmarkTests.scala:34)
-[info]  at sauerkraut.benchmarks.SimpleMessage$$anon$1.write(BenchmarkTests.scala:34)
-[info]  at sauerkraut.core.CollectionWriter.write$$anonfun$2$$anonfun$1$$anonfun$1(collections.scala:32)
-[info]  at dotty.runtime.function.JProcedure1.apply(JProcedure1.java:15)
-[info]  at dotty.runtime.function.JProcedure1.apply(JProcedure1.java:10)
-[info]  at sauerkraut.format.pb.ProtocolBufferFieldWriter.putElement(writer.scala:62)
-[info]  at sauerkraut.core.CollectionWriter.write$$anonfun$3$$anonfun$2(collections.scala:32)
-[info]  at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:553)
-[info]  at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:551)
-[info]  at scala.collection.AbstractIterable.foreach(Iterable.scala:920)
-[info]  at sauerkraut.core.CollectionWriter.write$$anonfun$1(collections.scala:32)
-[info]  at dotty.runtime.function.JProcedure1.apply(JProcedure1.java:15)
-[info]  at dotty.runtime.function.JProcedure1.apply(JProcedure1.java:10)
-[info]  at sauerkraut.format.pb.ProtocolBufferFieldWriter.putCollection(writer.scala:31)
-[info]  at sauerkraut.core.CollectionWriter.write(collections.scala:32)
-[info]  at sauerkraut.core.CollectionWriter.write(collections.scala:29)
-[info]  at sauerkraut.benchmarks.LargerMessage$.write$$anonfun$1$$anonfun$1(BenchmarkTests.scala:40)
-[info]  at dotty.runtime.function.JProcedure1.apply(JProcedure1.java:15)
-[info]  at dotty.runtime.function.JProcedure1.apply(JProcedure1.java:10)
-[info]  at sauerkraut.format.pb.DescriptorBasedProtoStructureWriter.putField(writer.scala:74)
-[info]  at sauerkraut.benchmarks.LargerMessage$.sauerkraut$benchmarks$LargerMessage$$anon$1$$_$write$$anonfun$4(BenchmarkTests.scala:40)
-[info]  at dotty.runtime.function.JProcedure1.apply(JProcedure1.java:15)
-[info]  at dotty.runtime.function.JProcedure1.apply(JProcedure1.java:10)
-[info]  at sauerkraut.format.pb.DescriptorBasedProtoWriter.putStructure(writer.scala:85)
-[info]  at sauerkraut.benchmarks.LargerMessage$$anon$1.write(BenchmarkTests.scala:40)
-[info]  at sauerkraut.benchmarks.LargerMessage$$anon$1.write(BenchmarkTests.scala:40)
-[info]  at sauerkraut.api$package$.write(api.scala:49)
-[info]  at sauerkraut.benchmarks.SauerkrautProtocolBufferBenchmarks.save(BenchmarkTests.scala:130)
-[info]  at sauerkraut.benchmarks.JmhBenchmarks.inline$save(BenchmarkTests.scala:71)
-[info]  at sauerkraut.benchmarks.JmhBenchmarks.writeAndReadLargeNestedMessage(BenchmarkTests.scala:91)
-      */
-      case _ => throw RuntimeException(s"Cannot find structure definition from: $desc")
+      case _ => 
+        throw RuntimeException(s"Cannot find structure definition from: $desc")
     this
 
   override def putPrimitive(picklee: Any, tag: PrimitiveTag[?]): PickleWriter =

--- a/pb/src/test/scala/sauerkraut/format/pb/descriptors.scala
+++ b/pb/src/test/scala/sauerkraut/format/pb/descriptors.scala
@@ -7,6 +7,7 @@ import org.junit.Test
 import org.junit.Assert._
 import core.{Buildable,Writer,given}
 import scala.collection.mutable.ArrayBuffer
+import pretty.{Pretty, given}
 
 // Example from: https://developers.google.com/protocol-buffers/docs/encoding
 // ```
@@ -39,17 +40,19 @@ val MyProtos = Protos[(Nested, Nesting, NestedCollections)]()
 class TestProtocolBufferWithDesc:
   def hexString(buf: Array[Byte]): String =
     buf.map(b => f"$b%02x").mkString("")
-  def binaryWithDesc[T: Writer : ProtoTypeDescriptor](value: T): Array[Byte] =
-    val out = java.io.ByteArrayOutputStream()
-    pickle(MyProtos).to(out).write(value)
+  def binaryWithDesc[T: Writer : ProtoTypeDescriptor](value: T): Array[Byte] =    
+    val out = java.io.ByteArrayOutputStream()    
+    pickle(MyProtos).to(out).write(value)    
     out.toByteArray()
   def binaryStringWithDesc[T : Writer : ProtoTypeDescriptor](value: T): String =
     hexString(binaryWithDesc(value))
 
-  def roundTrip[T : Buildable : Writer](value: T): Unit =
+  def roundTrip[T : Buildable : Writer : ProtoTypeDescriptor](value: T): Unit =
     val out = java.io.ByteArrayOutputStream()
     pickle(MyProtos).to(out).write(value)
-    val in = java.io.ByteArrayInputStream(out.toByteArray())
+    val bytes = out.toByteArray()
+    System.err.println(s"Pickled:\n${hexString(bytes)}\n\n")
+    val in = java.io.ByteArrayInputStream(bytes)
     assertEquals(s"Failed to roundtrip", value, pickle(MyProtos).from(in).read[T])
 
   @Test def writeNested(): Unit =
@@ -58,4 +61,19 @@ class TestProtocolBufferWithDesc:
   @Test def roundTrip(): Unit =
     roundTrip(Nesting(150))
     roundTrip(Nested(Nesting(150)))
+    roundTrip(NestedCollections(ArrayBuffer(Nesting(150)), ArrayBuffer(), ArrayBuffer()))
     roundTrip(NestedCollections(ArrayBuffer(Nesting(1)), ArrayBuffer(2.0, 3.0), ArrayBuffer(1L, 4L)))
+
+  @Test def codegen(): Unit =
+    summon[ProtoTypeDescriptor[NestedCollections]] match
+      case msg: MessageProtoDescriptor[?] =>
+        assertEquals("Failed to find correct field name", "messages", msg.fieldName(1))
+        assertEquals("Failed to find correct field number", 1, msg.fieldNumber("messages"))
+        assertEquals("Failed to find correct field descriptor for `messages: ArrayBuffer[Nesting] @field(1)`", fastTypeTag[ArrayBuffer[Nesting]](), msg.fieldDesc(1).tag)
+        assertEquals("Failed to find correct field name", "otherNums", msg.fieldName(2))
+        assertEquals("Failed to find correct field number", 2, msg.fieldNumber("otherNums"))
+        assertEquals("Failed to find correct field descriptor for `otherNums: ArrayBuffer[Double] @field(2)`", fastTypeTag[ArrayBuffer[Double]](), msg.fieldDesc(2).tag)
+        assertEquals("Failed to find correct field name", "ints", msg.fieldName(3))
+        assertEquals("Failed to find correct field number", 3, msg.fieldNumber("ints"))
+        assertEquals("Failed to find correct field descriptor for `ints: ArrayBuffer[Long] @field(3)`", fastTypeTag[ArrayBuffer[Long]](), msg.fieldDesc(3).tag)
+      case other => fail(s"Expected to generated message proto descriptor, got: $other")

--- a/pb/src/test/scala/sauerkraut/format/pb/descriptors.scala
+++ b/pb/src/test/scala/sauerkraut/format/pb/descriptors.scala
@@ -6,6 +6,7 @@ import sauerkraut.{read,write}
 import org.junit.Test
 import org.junit.Assert._
 import core.{Buildable,Writer,given}
+import scala.collection.mutable.ArrayBuffer
 
 // Example from: https://developers.google.com/protocol-buffers/docs/encoding
 // ```
@@ -24,8 +25,16 @@ case class Nesting(a: Int @field(1))
 case class Nested(c: Nesting @field(3))
   derives Buildable, Writer, ProtoTypeDescriptor
 
-val MyProtos = Protos[(Nested, Nesting)]()
+
+case class NestedCollections(
+  messages: ArrayBuffer[Nesting] @field(1),
+  otherNums: ArrayBuffer[Double] @field(2),
+  ints: ArrayBuffer[Long] @field(3)
+) derives Writer, Buildable, ProtoTypeDescriptor
+
+val MyProtos = Protos[(Nested, Nesting, NestedCollections)]()
       
+
 
 class TestProtocolBufferWithDesc:
   def hexString(buf: Array[Byte]): String =
@@ -49,3 +58,4 @@ class TestProtocolBufferWithDesc:
   @Test def roundTrip(): Unit =
     roundTrip(Nesting(150))
     roundTrip(Nested(Nesting(150)))
+    roundTrip(NestedCollections(ArrayBuffer(Nesting(1)), ArrayBuffer(2.0, 3.0), ArrayBuffer(1L, 4L)))

--- a/pb/src/test/scala/sauerkraut/format/pb/raw.scala
+++ b/pb/src/test/scala/sauerkraut/format/pb/raw.scala
@@ -4,7 +4,7 @@ package pb
 
 import org.junit.Test
 import org.junit.Assert._
-import core.{Writer,given _}
+import core.{Writer,given}
 
 case class Derived(x: Boolean, test: String) derives Writer
 case class Repeated(x: List[Boolean]) derives Writer


### PR DESCRIPTION
Still not a 100% implementation, but enough for some more benchmarking.

- Update `Buildable`/`Builder` macros to do less "dumb" instantiation of nested objects all the time.
- Update `ProtoDescriptor` macros to use consistent ordering for types as is used for the typeclass derivation.
- Update ProtoDescriptorWriter to be more collection friendly (still too many todos).