### PR TITLE
Limit dependencies in Sauerkraut

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ Latest status/analysis can be found in the [benchmarks directory](benchmarks/lat
   - [X] RawBinary + Protos vs. protocol buffer java implementation
   - [ ] Json Reading vs. raw JAWN to AST (measure overhead)
   - [ ] Jackson
-  - [X] Avro
+  - [X] Kryo
   - [ ] Thrift
   - [ ] Circe
   - [ ] uPickle

--- a/benchmarks/latest-results.md
+++ b/benchmarks/latest-results.md
@@ -39,6 +39,7 @@ numbers from the naive implementation into something ready-for-production.
 
 ## Areas to investigate:
 
+- [ ] Create byte-buffer writing utilties via `sun.misc.Unsafe`.
 - [X] Figure out where immutable.List.length is being called from (22.8%)
   - `Field.unapply` in RawBinaryReader was the issue.
   - We were doing validation that tags read MATCH what we see in

--- a/benchmarks/src/main/scala/sauerkraut/benchmarks/HeadRoomBenchmark.scala
+++ b/benchmarks/src/main/scala/sauerkraut/benchmarks/HeadRoomBenchmark.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package sauerkraut.benchmarks
 package headroom
 

--- a/build.sbt
+++ b/build.sbt
@@ -35,6 +35,15 @@ ThisBuild / organizationName := "Google"
 val core = project
   .settings(commonSettings:_*)
 
+val utils = project
+  .settings(commonSettings:_*)
+  .dependsOn(core)
+  .settings(
+    libraryDependencies += "junit" % "junit" % "4.11",
+    // For comparisons
+    libraryDependencies += "com.google.protobuf" % "protobuf-java" % "3.11.3" % "test"
+  )
+
 val compliance = project
   .settings(commonSettings:_*)
   .dependsOn(core)
@@ -51,7 +60,7 @@ val json = project
 
 val pb = project
   .settings(commonSettings:_*)
-  .dependsOn(core, compliance % "test")
+  .dependsOn(core, utils, compliance % "test")
   .settings(
     libraryDependencies += "com.google.protobuf" % "protobuf-java" % "3.11.3"
   )

--- a/build.sbt
+++ b/build.sbt
@@ -79,7 +79,7 @@ val pbtest = project
 
 val nbt = project
   .settings(commonSettings:_*)
-  .dependsOn(core, compliance % "test")
+  .dependsOn(core, utils, compliance % "test")
 
 val xml = project
   .settings(commonSettings:_*)

--- a/build.sbt
+++ b/build.sbt
@@ -61,9 +61,6 @@ val json = project
 val pb = project
   .settings(commonSettings:_*)
   .dependsOn(core, utils, compliance % "test")
-  .settings(
-    libraryDependencies += "com.google.protobuf" % "protobuf-java" % "3.11.3"
-  )
 
 val pbtest = project
   .settings(commonSettings:_*)

--- a/nbt/src/main/scala/sauerkraut/format/nbt/format.scala
+++ b/nbt/src/main/scala/sauerkraut/format/nbt/format.scala
@@ -32,7 +32,7 @@ object Nbt extends PickleFormat
 
 given [O <: OutputStream]: PickleWriterSupport[O, Nbt.type] with
   def writerFor(format: Nbt.type, output: O): PickleWriter =
-    NbtPickleWriter(internal.TagOutputStream(DataOutputStream(output)))
+    NbtPickleWriter(internal.TagOutputStream(output))
 
 given [I <: InputStream]: PickleReaderSupport[I, Nbt.type] with
   def readerFor(format: Nbt.type, input: I): PickleReader =

--- a/nbt/src/main/scala/sauerkraut/format/nbt/internal/TagOutputStream.scala
+++ b/nbt/src/main/scala/sauerkraut/format/nbt/internal/TagOutputStream.scala
@@ -19,78 +19,47 @@ package format
 package nbt
 package internal
 
-import java.io.DataOutputStream
+import java.io.OutputStream
+import sauerkraut.utils.InlineWriter
+import InlineWriter.Endian
 import NbtTag._
 
-class TagOutputStream(out: DataOutputStream):
+/** Helper class to output Tags + Payloads for NBT format. */
+class TagOutputStream(out: OutputStream):
   /** Writes a raw tag-id, with no paylod. */
-  def writeRawTag(tag: NbtTag): Unit =
-    out.writeByte(tag.id)
-  def writeStringPayload(value: String): Unit =
-    out.writeUTF(value)
+  def writeRawTag(tag: NbtTag): Unit = out.write(tag.id)
+  def writeStringPayload(value: String): Unit = 
+    // We likely want to check and make sure this is really how NBT does it..
+    val bytes = value.getBytes(InlineWriter.Utf8)    
+    writeShortPayload(bytes.length.toShort)
+    out.write(bytes)
+    //out.writeUTF(value)
   def writeBytePayload(value: Byte): Unit =
-    out.writeByte(value.toInt)
+    out.write(value.toInt)
   def writeShortPayload(value: Short): Unit =
-    out.writeShort(value.toInt)
+    InlineWriter.writeFixed16(value, (x) => out.write(x), Endian.Big)
+    // out.writeShort(value.toInt)
   def writeIntPayload(value: Int): Unit =
-    out.writeInt(value)
+    InlineWriter.writeFixed32(value, (x) => out.write(x), Endian.Big)
+    // out.writeInt(value)
   def writeLongPayload(value: Long): Unit =
-    out.writeLong(value)
+    InlineWriter.writeFixed64(value, (x) => out.write(x), Endian.Big)
+    // out.writeLong(value)
   def writeFloatPayload(value: Float): Unit =
-    out.writeFloat(value)
+    InlineWriter.writeFloat(value, (x) => out.write(x), Endian.Big)
+    // out.writeFloat(value)
   def writeDoublePayload(value: Double): Unit =
-    out.writeDouble(value)
+    InlineWriter.writeDouble(value, (x) => out.write(x), Endian.Big)
+    // out.writeDouble(value)
   def writeBytesPayload(value: Array[Byte]): Unit =
-    out.writeInt(value.length)
+    writeIntPayload(value.length)
     out.write(value)
   def writeIntArrayPayload(value: Array[Int]): Unit =
-    out.writeInt(value.length)
-    value.foreach(out.writeInt)
+    writeIntPayload(value.length)
+    value.foreach(writeIntPayload)
   def writeLongArrayPayload(value: Array[Long]): Unit =
-    out.writeInt(value.length)
-    value.foreach(out.writeLong)
-
-  def writeTag[T](tag: PrimitiveTag[T]): Unit =
-    import PrimitiveTag._
-    tag match
-      case UnitTag => ()
-      case BooleanTag => writeRawTag(NbtTag.TagByte)
-      case ByteTag => writeRawTag(NbtTag.TagByte)
-      case CharTag => writeRawTag(NbtTag.TagShort)
-      case ShortTag => writeRawTag(NbtTag.TagShort)
-      case IntTag => writeRawTag(NbtTag.TagInt)
-      case LongTag => writeRawTag(NbtTag.TagLong)
-      case FloatTag => writeRawTag(NbtTag.TagFloat)
-      case DoubleTag => writeRawTag(NbtTag.TagDouble)
-      case StringTag => writeRawTag(NbtTag.TagString)
-
-  def writePayload[T](picklee: T, tag: PrimitiveTag[T]): Unit =
-    import PrimitiveTag._
-    tag match
-        case UnitTag => ()
-        case BooleanTag => 
-            writeBytePayload(
-                if picklee.asInstanceOf[Boolean] 
-                then 1.toByte 
-                else 0.toByte)
-        case ByteTag =>
-            writeBytePayload(picklee.asInstanceOf[Byte])
-        case CharTag =>
-            writeShortPayload(picklee.asInstanceOf[Char].toShort)
-        case ShortTag =>
-            writeShortPayload(picklee.asInstanceOf[Short])
-        case IntTag =>
-            writeIntPayload(picklee.asInstanceOf[Int])
-        case LongTag =>
-            writeLongPayload(picklee.asInstanceOf[Long])
-        case FloatTag =>
-            writeFloatPayload(picklee.asInstanceOf[Float])
-        case DoubleTag =>
-            writeDoublePayload(picklee.asInstanceOf[Double])
-        case StringTag =>
-            writeStringPayload(picklee.asInstanceOf[String])
-
-
+    writeIntPayload(value.length)
+    value.foreach(writeLongPayload)
   def flush(): Unit = out.flush()
   def close(): Unit = out.close()
 

--- a/nbt/src/main/scala/sauerkraut/format/nbt/internal/TagOutputStream.scala
+++ b/nbt/src/main/scala/sauerkraut/format/nbt/internal/TagOutputStream.scala
@@ -20,8 +20,10 @@ package nbt
 package internal
 
 import java.io.OutputStream
-import sauerkraut.utils.InlineWriter
-import InlineWriter.Endian
+import sauerkraut.utils.{
+  Endian,
+  InlineWriter
+}
 import NbtTag._
 
 /** Helper class to output Tags + Payloads for NBT format. */

--- a/pb/src/main/scala/sauerkraut/format/pb/format.scala
+++ b/pb/src/main/scala/sauerkraut/format/pb/format.scala
@@ -20,7 +20,7 @@ package pb
 
 import java.nio.ByteBuffer
 import java.io.{InputStream,OutputStream}
-import com.google.protobuf.{CodedInputStream,CodedOutputStream}
+import com.google.protobuf.{CodedInputStream}
 
 /** 
  * A binary format that is protocol-buffer like, but will not allow
@@ -30,24 +30,24 @@ object RawBinary extends PickleFormat
 
 given [O <: OutputStream]: PickleWriterSupport[O, RawBinary.type] with
   def writerFor(format: RawBinary.type, output: O): PickleWriter = 
-    RawBinaryPickleWriter(CodedOutputStream.newInstance(output))
+    RawBinaryPickleWriter(streams.ProtoOutputStream(output))
 
 given [I <: InputStream]: PickleReaderSupport[I, RawBinary.type] with
   def readerFor(format: RawBinary.type, input: I): PickleReader = 
     RawBinaryPickleReader(CodedInputStream.newInstance(input))
 
 
-given PickleWriterSupport[Array[Byte], RawBinary.type] with
-  def writerFor(format: RawBinary.type, output: Array[Byte]): PickleWriter = 
-    RawBinaryPickleWriter(CodedOutputStream.newInstance(output))
+// given PickleWriterSupport[Array[Byte], RawBinary.type] with
+//   def writerFor(format: RawBinary.type, output: Array[Byte]): PickleWriter = 
+//     RawBinaryPickleWriter(streams.ProtoOutputStream(output))
 
 given PickleReaderSupport[Array[Byte], RawBinary.type] with
   def readerFor(format: RawBinary.type, input: Array[Byte]): PickleReader =
     RawBinaryPickleReader(CodedInputStream.newInstance(new java.io.ByteArrayInputStream(input)))
 
-given PickleWriterSupport[ByteBuffer, RawBinary.type] with
-  def writerFor(format: RawBinary.type, output: ByteBuffer): PickleWriter = 
-    RawBinaryPickleWriter(CodedOutputStream.newInstance(output))
+// given PickleWriterSupport[ByteBuffer, RawBinary.type] with
+//   def writerFor(format: RawBinary.type, output: ByteBuffer): PickleWriter = 
+//     RawBinaryPickleWriter(streams.ProtoOutputStream(output))
 
 given PickleReaderSupport[ByteBuffer, RawBinary.type] with
   def readerFor(format: RawBinary.type, input: ByteBuffer): PickleReader =
@@ -71,11 +71,11 @@ object Protos:
 
 given [O <: OutputStream, P <: Protos]: PickleWriterSupport[O, P] with
   def writerFor(protos: P, output: O): PickleWriter =
-    DescriptorBasedProtoWriter(CodedOutputStream.newInstance(output), protos.repository)
+    DescriptorBasedProtoWriter(streams.ProtoOutputStream(output), protos.repository)
 
-given [P <: Protos]: PickleWriterSupport[ByteBuffer, P] with
-  def writerFor(protos: P, output: ByteBuffer): PickleWriter = 
-    DescriptorBasedProtoWriter(CodedOutputStream.newInstance(output), protos.repository)
+// given [P <: Protos]: PickleWriterSupport[ByteBuffer, P] with
+//   def writerFor(protos: P, output: ByteBuffer): PickleWriter = 
+//     DescriptorBasedProtoWriter(streams.ProtoOutputStream(output), protos.repository)
 
 
 given [I <: InputStream, P <: Protos]: PickleReaderSupport[I, P] with

--- a/pb/src/main/scala/sauerkraut/format/pb/format.scala
+++ b/pb/src/main/scala/sauerkraut/format/pb/format.scala
@@ -20,7 +20,6 @@ package pb
 
 import java.nio.ByteBuffer
 import java.io.{InputStream,OutputStream}
-import com.google.protobuf.{CodedInputStream}
 
 /** 
  * A binary format that is protocol-buffer like, but will not allow

--- a/pb/src/main/scala/sauerkraut/format/pb/format.scala
+++ b/pb/src/main/scala/sauerkraut/format/pb/format.scala
@@ -34,7 +34,7 @@ given [O <: OutputStream]: PickleWriterSupport[O, RawBinary.type] with
 
 given [I <: InputStream]: PickleReaderSupport[I, RawBinary.type] with
   def readerFor(format: RawBinary.type, input: I): PickleReader = 
-    RawBinaryPickleReader(CodedInputStream.newInstance(input))
+    RawBinaryPickleReader(streams.ProtoInputStream(input))
 
 
 // given PickleWriterSupport[Array[Byte], RawBinary.type] with
@@ -43,15 +43,15 @@ given [I <: InputStream]: PickleReaderSupport[I, RawBinary.type] with
 
 given PickleReaderSupport[Array[Byte], RawBinary.type] with
   def readerFor(format: RawBinary.type, input: Array[Byte]): PickleReader =
-    RawBinaryPickleReader(CodedInputStream.newInstance(new java.io.ByteArrayInputStream(input)))
+    RawBinaryPickleReader(streams.ProtoInputStream(new java.io.ByteArrayInputStream(input)))
 
 // given PickleWriterSupport[ByteBuffer, RawBinary.type] with
 //   def writerFor(format: RawBinary.type, output: ByteBuffer): PickleWriter = 
 //     RawBinaryPickleWriter(streams.ProtoOutputStream(output))
 
-given PickleReaderSupport[ByteBuffer, RawBinary.type] with
-  def readerFor(format: RawBinary.type, input: ByteBuffer): PickleReader =
-    RawBinaryPickleReader(CodedInputStream.newInstance(input))
+// given PickleReaderSupport[ByteBuffer, RawBinary.type] with
+//   def readerFor(format: RawBinary.type, input: ByteBuffer): PickleReader =
+//     RawBinaryPickleReader(CodedInputStream.newInstance(input))
 
 /**
  * A binary format that allows the encoding of specific protocol
@@ -80,9 +80,9 @@ given [O <: OutputStream, P <: Protos]: PickleWriterSupport[O, P] with
 
 given [I <: InputStream, P <: Protos]: PickleReaderSupport[I, P] with
   def readerFor(protos: P, input: I): PickleReader =
-    DescriptorBasedProtoReader(CodedInputStream.newInstance(input), protos.repository)
+    DescriptorBasedProtoReader(streams.ProtoInputStream(input), protos.repository)
 
 
-given [P <: Protos]: PickleReaderSupport[ByteBuffer, P] with
-  def readerFor(protos: P, input: ByteBuffer): PickleReader =
-    DescriptorBasedProtoReader(CodedInputStream.newInstance(input), protos.repository)
+// given [P <: Protos]: PickleReaderSupport[ByteBuffer, P] with
+//   def readerFor(protos: P, input: ByteBuffer): PickleReader =
+//     DescriptorBasedProtoReader(CodedInputStream.newInstance(input), protos.repository)

--- a/pb/src/main/scala/sauerkraut/format/pb/raw_reader.scala
+++ b/pb/src/main/scala/sauerkraut/format/pb/raw_reader.scala
@@ -18,8 +18,11 @@ package sauerkraut
 package format
 package pb
 
+import streams.{
+  LimitableTagReadingStream
+}
+
 import com.google.protobuf.{
-  CodedInputStream,
   WireFormat
 }
 import WireFormat.{
@@ -30,7 +33,7 @@ object Tag:
   inline def unapply(tag: Int): (Int, Int) =
     (WireFormat.getTagWireType(tag), WireFormat.getTagFieldNumber(tag))
 
-class RawBinaryPickleReader(in: CodedInputStream)
+class RawBinaryPickleReader(in: LimitableTagReadingStream)
   extends PickleReader:
   override def push[T](b: core.Builder[T]): core.Builder[T] =
     b match
@@ -52,7 +55,7 @@ class RawBinaryPickleReader(in: CodedInputStream)
         else None
     var done: Boolean = false
     while (!done)
-      in.readTag match
+      in.readTag() match
         // TODO - if we hit any field we don't recognize, we quit.
         case 0 => done = true
         // Special case string (and packed) types so we don't read the length.
@@ -71,7 +74,7 @@ class RawBinaryPickleReader(in: CodedInputStream)
           }
         case _ => done = true
   private def readChoice[T](choice: core.ChoiceBuilder[T]): Unit =
-    in.readTag match
+    in.readTag() match
       case 0 => ()
       case Tag(wireType, ordinal) =>
         Shared.limitByWireType(in)(wireType) {
@@ -82,7 +85,7 @@ class RawBinaryPickleReader(in: CodedInputStream)
   private def readCollection[E, To](c: core.CollectionBuilder[E, To]): Unit  =
     // Collections are written as:
     // [TAG] [LengthInBytes] [LengthOfCollection] [Element]*
-    var length = in.readRawVarint32()
+    var length = in.readVarInt32()
     c.sizeHint(length)
     while (length > 0)
       push(c.putElement())

--- a/pb/src/main/scala/sauerkraut/format/pb/raw_reader.scala
+++ b/pb/src/main/scala/sauerkraut/format/pb/raw_reader.scala
@@ -19,19 +19,10 @@ package format
 package pb
 
 import streams.{
-  LimitableTagReadingStream
-}
-
-import com.google.protobuf.{
+  LimitableTagReadingStream,
+  Tag,
   WireFormat
 }
-import WireFormat.{
-  WIRETYPE_LENGTH_DELIMITED
-}
-
-object Tag:
-  inline def unapply(tag: Int): (Int, Int) =
-    (WireFormat.getTagWireType(tag), WireFormat.getTagFieldNumber(tag))
 
 class RawBinaryPickleReader(in: LimitableTagReadingStream)
   extends PickleReader:
@@ -59,7 +50,7 @@ class RawBinaryPickleReader(in: LimitableTagReadingStream)
         // TODO - if we hit any field we don't recognize, we quit.
         case 0 => done = true
         // Special case string (and packed) types so we don't read the length.
-        case Tag(WIRETYPE_LENGTH_DELIMITED,
+        case Tag(WireFormat.LengthDelimited,
                  fieldNum @ Field(fieldBuilder: core.PrimitiveBuilder[?])) =>
           // Don't read the length, string read will do this.
           push(fieldBuilder)

--- a/pb/src/main/scala/sauerkraut/format/pb/reader.scala
+++ b/pb/src/main/scala/sauerkraut/format/pb/reader.scala
@@ -18,15 +18,18 @@ package sauerkraut
 package format
 package pb
 
+import streams.{
+  LimitableTagReadingStream
+}
+
 import com.google.protobuf.{
-  CodedInputStream,
   WireFormat
 }
 import WireFormat.{
   WIRETYPE_LENGTH_DELIMITED
 }
 
-class DescriptorBasedProtoReader(in: CodedInputStream, repo: TypeDescriptorRepository)
+class DescriptorBasedProtoReader(in: LimitableTagReadingStream, repo: TypeDescriptorRepository)
     extends PickleReader:
   def push[T](b: core.Builder[T]): core.Builder[T] =
     b match
@@ -77,7 +80,7 @@ class DescriptorBasedProtoReader(in: CodedInputStream, repo: TypeDescriptorRepos
           case _: MatchError => None
     var done: Boolean = false
     while !done do
-      in.readTag match
+      in.readTag() match
         case 0 => done = true
         case Tag(wireType, num @ FieldName(field)) =>
           readField(struct.putField(field), mapping.fieldDesc(num), wireType)

--- a/pb/src/main/scala/sauerkraut/format/pb/reader.scala
+++ b/pb/src/main/scala/sauerkraut/format/pb/reader.scala
@@ -19,14 +19,9 @@ package format
 package pb
 
 import streams.{
-  LimitableTagReadingStream
-}
-
-import com.google.protobuf.{
+  LimitableTagReadingStream,
+  Tag,
   WireFormat
-}
-import WireFormat.{
-  WIRETYPE_LENGTH_DELIMITED
 }
 
 class DescriptorBasedProtoReader(in: LimitableTagReadingStream, repo: TypeDescriptorRepository)
@@ -48,23 +43,23 @@ class DescriptorBasedProtoReader(in: LimitableTagReadingStream, repo: TypeDescri
       case e: ClassCastException => throw BuildException(s"Builder error.  Builder: $b, Descriptor: $desc", e)
     b
 
-  private inline def readField[T](fieldBuilder: core.Builder[T], desc: ProtoTypeDescriptor[T], wireType: Int): Unit =
+  private inline def readField[T](fieldBuilder: core.Builder[T], desc: ProtoTypeDescriptor[T], wireType: WireFormat): Unit =
     try 
       fieldBuilder match {
         case choice: core.ChoiceBuilder[T] => ???
         case struct: core.StructureBuilder[T] =>
-          Shared.limitByWireType(in)(WIRETYPE_LENGTH_DELIMITED) {
+          Shared.limitByWireType(in)(WireFormat.LengthDelimited) {
             readStructure(struct, desc.asInstanceOf)
           }
         case col: core.CollectionBuilder[_,_] =>
           val colDesc = desc.asInstanceOf[CollectionTypeDescriptor[_,_]]
           colDesc.element match
             case x: PrimitiveTypeDescriptor[_] =>
-              if (wireType == WIRETYPE_LENGTH_DELIMITED) 
+              if WireFormat.LengthDelimited == wireType then
                 Shared.readCompressedPrimitive(in)(col, x.tag.asInstanceOf)
               else pushWithDesc(col.putElement(), x.asInstanceOf)
             case other =>
-              Shared.limitByWireType(in)(WIRETYPE_LENGTH_DELIMITED) {
+              Shared.limitByWireType(in)(WireFormat.LengthDelimited) {
                 pushWithDesc(col.putElement(), other.asInstanceOf)
               }
         case p: core.PrimitiveBuilder[_] => Shared.readPrimitive(in)(p)

--- a/pb/src/main/scala/sauerkraut/format/pb/shared.scala
+++ b/pb/src/main/scala/sauerkraut/format/pb/shared.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google
+ * Copyright 2019 Google
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pb/src/main/scala/sauerkraut/format/pb/shared.scala
+++ b/pb/src/main/scala/sauerkraut/format/pb/shared.scala
@@ -26,6 +26,7 @@ import com.google.protobuf.{
 import WireFormat.{
   WIRETYPE_LENGTH_DELIMITED
 }
+import streams.ProtoOutputStream
 
 /** Helper methods for implementing pb + raw protocols. */
 object Shared:
@@ -37,13 +38,13 @@ object Shared:
       }
     }
 
-  def writeCompressedPrimitives[E, To](out: CodedOutputStream, fieldNum: Int)(
+  def writeCompressedPrimitives[E, To](out: ProtoOutputStream, fieldNum: Int)(
     work: PickleCollectionWriter => Unit): Unit =
-    out.writeTag(fieldNum, WIRETYPE_LENGTH_DELIMITED)
+    out.writeInt(streams.WireFormat.LengthDelimited.makeTag(fieldNum))
     // TODO - we want a size estimator for protos w/ descriptors...
     val sizeEstimate = CompressedPrimitiveCollectionSizeEstimator()
     work(sizeEstimate)
-    out.writeInt32NoTag(sizeEstimate.finalSize)
+    out.writeInt(sizeEstimate.finalSize)
     // Write the primitives...
     work(CompressedPrimitiveCollectionWriter(out))
 
@@ -72,7 +73,7 @@ object Shared:
     else f
 
 /** Pickle writer that can only write compressed repeated primitive fields. */
-class CompressedPrimitiveCollectionWriter(out: CodedOutputStream) extends PickleCollectionWriter with PickleWriter:
+class CompressedPrimitiveCollectionWriter(out: ProtoOutputStream) extends PickleCollectionWriter with PickleWriter:
   override def flush(): Unit = out.flush()
   override def putElement(pickler: PickleWriter => Unit): PickleCollectionWriter =
     pickler(this)
@@ -83,31 +84,31 @@ class CompressedPrimitiveCollectionWriter(out: CodedOutputStream) extends Pickle
   override def putUnit(): PickleWriter = 
     this
   override def putBoolean(value: Boolean): PickleWriter =
-    out.writeBoolNoTag(value)
+    out.writeBoolean(value)
     this
   override def putByte(value: Byte): PickleWriter =
-    out.writeInt32NoTag(value.toInt)
+    out.writeInt(value.toInt)
     this
   override def putChar(value: Char): PickleWriter = 
-    out.writeInt32NoTag(value.toInt)
+    out.writeInt(value.toInt)
     this
   override def putShort(value: Short): PickleWriter =
-    out.writeInt32NoTag(value.toInt)
+    out.writeInt(value.toInt)
     this
   override def putInt(value: Int): PickleWriter = 
-    out.writeInt32NoTag(value)
+    out.writeInt(value)
     this
   override def putLong(value: Long): PickleWriter =
-    out.writeInt64NoTag(value)
+    out.writeLong(value)
     this
   override def putFloat(value: Float): PickleWriter =
-    out.writeFloatNoTag(value)
+    out.writeFloat(value)
     this
   override def putDouble(value: Double): PickleWriter =
-    out.writeDoubleNoTag(value)
+    out.writeDouble(value)
     this
   override def putString(value: String): PickleWriter =
-    out.writeStringNoTag(value)
+    out.writeString(value)
     this
 
 

--- a/pb/src/main/scala/sauerkraut/format/pb/streams/ProtoInputStream.scala
+++ b/pb/src/main/scala/sauerkraut/format/pb/streams/ProtoInputStream.scala
@@ -17,7 +17,10 @@
 package sauerkraut.format.pb.streams
 
 
-import sauerkraut.utils.InlineReader
+import sauerkraut.utils.{
+  Endian,
+  InlineReader
+}
 import java.io.InputStream
 
 
@@ -122,8 +125,8 @@ class ProtoInputStream(in: InputStream) extends LimitableTagReadingStream:
   final def readString(lengthInBytes: Int): String = InlineReader.readStringUtf8(lengthInBytes, () => readNext())
   override final def readByte(): Byte = readNext().toByte
   override final def readBoolean(): Boolean = InlineReader.readBoolean(() => readNext())
-  override final def readFloat(): Float = InlineReader.readFloat(() => readNext(), InlineReader.Endian.Little)
-  override final def readDouble(): Double = InlineReader.readDouble(() => readNext(), InlineReader.Endian.Little)
+  override final def readFloat(): Float = InlineReader.readFloat(() => readNext(), Endian.Little)
+  override final def readDouble(): Double = InlineReader.readDouble(() => readNext(), Endian.Little)
   override final def readVarInt32(): Int = InlineReader.readVarInt32(() => readNext())
   override final def readVarInt64(): Long = InlineReader.readVarInt64(() => readNext())
 

--- a/pb/src/main/scala/sauerkraut/format/pb/streams/ProtoInputStream.scala
+++ b/pb/src/main/scala/sauerkraut/format/pb/streams/ProtoInputStream.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package sauerkraut.format.pb.streams
 
 

--- a/pb/src/main/scala/sauerkraut/format/pb/streams/ProtoInputStream.scala
+++ b/pb/src/main/scala/sauerkraut/format/pb/streams/ProtoInputStream.scala
@@ -1,0 +1,123 @@
+package sauerkraut.format.pb.streams
+
+
+import sauerkraut.utils.InlineReader
+import java.io.InputStream
+
+
+/**
+ * The interface from CodedInputStream we used to first implement protocol buffer reading.
+ * 
+ * We stick with this as close as possible for now, until we push our own impl given enough time / benchmarking
+ * of alternative options.
+ */
+trait LimitableTagReadingStream:
+  /**
+   * Sets the current byte reading limit to `{current positon}` + `byteLimit`.
+   * 
+   * This limit only affects two portions of the input stream:
+   * 1. `bytesLeftUntilLimit` will accurately return the number of bytes you can
+   *    read before hitting the current limit.
+   * 2. `readTag` will return 0 if `bytesLeftUntilLimit` is < 1, and will not
+   *    read the underlying input until the current limit has been popped, or another
+   *    limit has been pushed.
+   */
+  def pushLimit(byteLimit: Int): Int
+  /**
+   * Discards the current limit, returning to the previous limit.
+   * 
+   * @param oldLimit The last limit, as returned by `pushLimit`.
+   */
+  def popLimit(oldLimit: Int): Unit
+
+  /** Performs an operation with a byte limit. */
+  inline def withLimit[T](limit: Int, inline work: LimitableTagReadingStream => T): T =
+    val last = pushLimit(limit)
+    try work(this)
+    finally popLimit(last)
+  /**
+   * @return True if there are no bytes left in the limit
+   */
+  def isAtEnd(): Boolean
+  /** Reads the next field tag in a proto stream.
+   * 
+   * @return a Protocol Buffer tag value or `0` if we've reached the end of the
+   *         stream or the current limit.
+   */
+  def readTag(): Int
+  /**
+   * Reads a single byte of input.
+   */
+  def readByte(): Byte
+  /**
+   * Reads an encoded boolean (one byte)
+   */
+  def readBoolean(): Boolean
+  /**
+   * Reads a VarInt of 32 bytes (positive inteegers) or 64 bytes (negative integers).
+   */
+  def readVarInt32(): Int
+  /**
+   * Reads a VarInt of 64 bytes maximum.
+   */
+  def readVarInt64(): Long
+  /**
+   * Reads a 32-bit floating point value.
+   */
+  def readFloat(): Float
+  /**
+   * Reads a 64-bit floating point value.
+   */
+  def readDouble(): Double
+  /**
+   * Reads a VarInt32 of length, then a UTF-8 encoded string in those bytes.
+   */
+  def readString(): String
+
+
+/** Our version of a protocol buffer input stream for use by raw + pb formats. */
+class ProtoInputStream(in: InputStream) extends LimitableTagReadingStream:
+  private var position: Int = 0
+  private var limit: Int = -1
+
+  override final def pushLimit(byteLimit: Int): Int =
+    val last = limit
+    // If we've never used a limit, reset our position to avoid overflow.
+    if last == -1 then position = 0
+    limit = position + byteLimit
+    last
+  override final def popLimit(oldLimit: Int): Unit =
+    limit = oldLimit
+  /** 
+   * Returns the number of bytes that can be read before reaching the current pushed limit.
+   * If no limit is set, returns -1
+   */
+  final def bytesUntilLimit: Int = 
+    if limit < 0 then Int.MaxValue else (limit - position)
+  override final def isAtEnd(): Boolean = bytesUntilLimit < 1
+  final def readNext(): Int = 
+    position += 1
+    in.read()
+
+  // TODO - mechanism to read raw bytes?
+  override final def readString(): String = 
+    val length = readVarInt32()
+    if (length > 0) then readString(length) else ""
+  final def readString(lengthInBytes: Int): String = InlineReader.readStringUtf8(lengthInBytes, () => readNext())
+  override final def readByte(): Byte = readNext().toByte
+  override final def readBoolean(): Boolean = InlineReader.readBoolean(() => readNext())
+  override final def readFloat(): Float = InlineReader.readFloat(() => readNext(), InlineReader.Endian.Little)
+  override final def readDouble(): Double = InlineReader.readDouble(() => readNext(), InlineReader.Endian.Little)
+  override final def readVarInt32(): Int = InlineReader.readVarInt32(() => readNext())
+  override final def readVarInt64(): Long = InlineReader.readVarInt64(() => readNext())
+
+  override def readTag(): Int =
+    if (limit >= 0) && (bytesUntilLimit < 1) then 0
+    else
+      // TODO - Check for end-of-stream.
+      val tag = readVarInt32()
+      // Note: CodedOutputStream did this to us a lot.  Do we want to do this, or allow `Raw` format to be crazy?
+      // if (WireFormat.extractField(tag) == 0) then throw InvalidTag(tag)
+
+      // TODO - better EOF detection...
+      if tag == -1 then 0 else tag

--- a/pb/src/main/scala/sauerkraut/format/pb/streams/ProtoOutputStream.scala
+++ b/pb/src/main/scala/sauerkraut/format/pb/streams/ProtoOutputStream.scala
@@ -1,0 +1,51 @@
+package sauerkraut.format.pb.streams
+
+import sauerkraut.utils.InlineWriter
+
+/** Helper output stream to write protocol buffers. */
+final class ProtoOutputStream(out: java.io.OutputStream):
+  def writeBoolean(value: Boolean): Unit = InlineWriter.writeBoolean(value, (x) => out.write(x))
+  def writeByte(value: Byte): Unit = InlineWriter.writeVarInt32(value.toInt, (x) => out.write(x))
+  def writeChar(value: Char): Unit = InlineWriter.writeVarInt32(value.toInt, (x) => out.write(x))
+  def writeShort(value: Short): Unit = InlineWriter.writeVarInt32(value.toInt, (x) => out.write(x))
+  def writeInt(value: Int): Unit = InlineWriter.writeVarInt32(value, (x) => out.write(x))
+  def writeLong(value: Long): Unit = InlineWriter.writeVarInt64(value, (x) => out.write(x))
+  def writeFloat(value: Float): Unit = InlineWriter.writeFloat(value, (x) => out.write(x), InlineWriter.Endian.Little)
+  def writeDouble(value: Double): Unit = InlineWriter.writeDouble(value, (x) => out.write(x), InlineWriter.Endian.Little)
+  def writeByteArray(bytes: Array[Byte]): Unit =
+    writeInt(bytes.length)
+    out.write(bytes)
+  def writeString(value: String): Unit = writeByteArray(value.getBytes(InlineWriter.Utf8))
+  
+
+  def writeBoolean(field: Int, value: Boolean): Unit = 
+    writeInt(WireFormat.VarInt.makeTag(field))
+    writeBoolean(value)
+  def writeByte(field: Int, value: Byte): Unit = 
+    writeInt(WireFormat.VarInt.makeTag(field))
+    writeByte(value)
+  def writeChar(field: Int, value: Char): Unit = 
+    writeInt(WireFormat.VarInt.makeTag(field))
+    writeChar(value)
+  def writeShort(field: Int, value: Short): Unit =
+    writeInt(WireFormat.VarInt.makeTag(field))
+    writeShort(value)
+  def writeInt(field: Int, value: Int): Unit =
+    writeInt(WireFormat.VarInt.makeTag(field))
+    writeInt(value)
+  def writeLong(field: Int, value: Long): Unit =
+    writeInt(WireFormat.VarInt.makeTag(field))
+    writeLong(value)
+  def writeFloat(field: Int, value: Float): Unit =
+    writeInt(WireFormat.Fixed32.makeTag(field))
+    writeFloat(value)
+  def writeDouble(field: Int, value: Double): Unit =
+    writeInt(WireFormat.Fixed64.makeTag(field))
+    writeDouble(value)
+  def writeByteArray(field: Int, bytes: Array[Byte]): Unit =
+    writeInt(WireFormat.LengthDelimited.makeTag(field))
+    writeByteArray(bytes)
+  def writeString(field: Int, value: String): Unit =
+    writeByteArray(field, value.getBytes(InlineWriter.Utf8))
+
+  def flush(): Unit = out.flush()

--- a/pb/src/main/scala/sauerkraut/format/pb/streams/ProtoOutputStream.scala
+++ b/pb/src/main/scala/sauerkraut/format/pb/streams/ProtoOutputStream.scala
@@ -16,8 +16,6 @@ final class ProtoOutputStream(out: java.io.OutputStream):
     writeInt(bytes.length)
     out.write(bytes)
   def writeString(value: String): Unit = writeByteArray(value.getBytes(InlineWriter.Utf8))
-  
-
   def writeBoolean(field: Int, value: Boolean): Unit = 
     writeInt(WireFormat.VarInt.makeTag(field))
     writeBoolean(value)

--- a/pb/src/main/scala/sauerkraut/format/pb/streams/ProtoOutputStream.scala
+++ b/pb/src/main/scala/sauerkraut/format/pb/streams/ProtoOutputStream.scala
@@ -16,7 +16,10 @@
 
 package sauerkraut.format.pb.streams
 
-import sauerkraut.utils.InlineWriter
+import sauerkraut.utils.{
+  Endian,
+  InlineWriter
+}
 
 /** Helper output stream to write protocol buffers. */
 final class ProtoOutputStream(out: java.io.OutputStream):
@@ -26,8 +29,8 @@ final class ProtoOutputStream(out: java.io.OutputStream):
   def writeShort(value: Short): Unit = InlineWriter.writeVarInt32(value.toInt, (x) => out.write(x))
   def writeInt(value: Int): Unit = InlineWriter.writeVarInt32(value, (x) => out.write(x))
   def writeLong(value: Long): Unit = InlineWriter.writeVarInt64(value, (x) => out.write(x))
-  def writeFloat(value: Float): Unit = InlineWriter.writeFloat(value, (x) => out.write(x), InlineWriter.Endian.Little)
-  def writeDouble(value: Double): Unit = InlineWriter.writeDouble(value, (x) => out.write(x), InlineWriter.Endian.Little)
+  def writeFloat(value: Float): Unit = InlineWriter.writeFloat(value, (x) => out.write(x), Endian.Little)
+  def writeDouble(value: Double): Unit = InlineWriter.writeDouble(value, (x) => out.write(x), Endian.Little)
   def writeByteArray(bytes: Array[Byte]): Unit =
     writeInt(bytes.length)
     out.write(bytes)

--- a/pb/src/main/scala/sauerkraut/format/pb/streams/ProtoOutputStream.scala
+++ b/pb/src/main/scala/sauerkraut/format/pb/streams/ProtoOutputStream.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package sauerkraut.format.pb.streams
 
 import sauerkraut.utils.InlineWriter

--- a/pb/src/main/scala/sauerkraut/format/pb/streams/ProtoWireSize.scala
+++ b/pb/src/main/scala/sauerkraut/format/pb/streams/ProtoWireSize.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package sauerkraut.format.pb.streams
 
 import sauerkraut.utils.{

--- a/pb/src/main/scala/sauerkraut/format/pb/streams/ProtoWireSize.scala
+++ b/pb/src/main/scala/sauerkraut/format/pb/streams/ProtoWireSize.scala
@@ -1,0 +1,31 @@
+package sauerkraut.format.pb.streams
+
+import sauerkraut.utils.{
+  VarInt,
+  InlineWriter
+}
+
+/**
+ * Helper utilities to calculate protocol buffer wire size for types.
+ */
+object ProtoWireSize:
+  inline def sizeOf(value: Boolean): Int = 1
+  inline def sizeOf(value: Byte): Int = 1
+  inline def sizeOf(value: Int): Int =  VarInt.byteSize(value)
+  inline def sizeOf(value: Long): Int =  VarInt.byteSize(value)
+  inline def sizeOf(value: Float): Int =  4
+  inline def sizeOf(value: Double): Int =  8
+  inline def sizeOf(value: String): Int = 
+    // TODO - Faster impl?
+    val length = value.getBytes(InlineWriter.Utf8).length
+    sizeOf(length) + length
+  inline def sizeOfTag(format: WireFormat, fieldNumber: Int): Int = sizeOf(format.makeTag(fieldNumber))
+
+
+  inline def sizeOf(field: Int, value: Boolean): Int = sizeOfTag(WireFormat.VarInt, field) + sizeOf(value)
+  inline def sizeOf(field: Int, value: Byte): Int = sizeOfTag(WireFormat.VarInt, field) + sizeOf(value)
+  inline def sizeOf(field: Int, value: Int): Int = sizeOfTag(WireFormat.VarInt, field) + sizeOf(value)
+  inline def sizeOf(field: Int, value: Long): Int = sizeOfTag(WireFormat.VarInt, field) + sizeOf(value)
+  inline def sizeOf(field: Int, value: Float): Int = sizeOfTag(WireFormat.Fixed32, field) + sizeOf(value)
+  inline def sizeOf(field: Int, value: Double): Int = sizeOfTag(WireFormat.Fixed64, field) + sizeOf(value)
+  inline def sizeOf(field: Int, value: String): Int = sizeOfTag(WireFormat.LengthDelimited, field) + sizeOf(value)

--- a/pb/src/main/scala/sauerkraut/format/pb/streams/WireFormat.scala
+++ b/pb/src/main/scala/sauerkraut/format/pb/streams/WireFormat.scala
@@ -18,18 +18,23 @@ package sauerkraut.format.pb.streams
 
 /** Wire format tags + flags for Protocol buffer encoding. */
 enum WireFormat(val flag: Int):
+  /** The next bit of data is encoded as a Variable-Length-Integer. */
   case VarInt extends WireFormat(0)
+  /** The next bit of data is 32-bits in size */
   case Fixed32 extends WireFormat(5)
+  /** The next bit of data is 54-bits in size */
   case Fixed64 extends WireFormat(1)
+  /** The next bit of data is a VarInt length, followed by that amoount of bytes. */
   case LengthDelimited extends WireFormat(2)
   // Unsupported:
   // - StartGroup, EndGroup
 
-  // Constructs a proto tag for the wireformat type and the field number.
+  /** Constructs a proto tag (VarInt value) for the wireformat type and the field number. */
   def makeTag(fieldNumber: Int): Int = (fieldNumber << 3) | flag
 
 object WireFormat:
-  def extractFormat(tag: Int): Int = (tag & 7)
+  private def extractFormat(tag: Int): Int = (tag & 7)
+  /** PUll the wire format out of a field tag. */
   def extract(tag: Int): WireFormat =
     extractFormat(tag) match
       case 0 => VarInt
@@ -37,10 +42,24 @@ object WireFormat:
       case 2 => LengthDelimited
       case 5 => Fixed32
       // TODO - good error message
+
+  /** Pulls the field number out of a field tag. */
   def extractField(tag: Int): Int = (tag >>> 3)
 
 /** Construct protocol buffer tag-varints for fields. */
 object Tag:
+  /** 
+   * Constructs a protocol buffer field tag 
+   * 
+   * @param format The wireformat for the field
+   * @param fieldNumber THe number of the field.
+   */
   inline def apply(format: WireFormat, fieldNumber: Int): Int = format.makeTag(fieldNumber)
+  /**
+   * Deconstructs a protocol buffer field tag.
+   * 
+   * @param tag The field tag value
+   * @return a tuple of the WireFormat and field number. 
+   */
   inline def unapply(tag: Int): (WireFormat, Int) =
     (WireFormat.extract(tag), WireFormat.extractField(tag))

--- a/pb/src/main/scala/sauerkraut/format/pb/streams/WireFormat.scala
+++ b/pb/src/main/scala/sauerkraut/format/pb/streams/WireFormat.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package sauerkraut.format.pb.streams
 
 /** Wire format tags + flags for Protocol buffer encoding. */

--- a/pb/src/main/scala/sauerkraut/format/pb/streams/WireFormat.scala
+++ b/pb/src/main/scala/sauerkraut/format/pb/streams/WireFormat.scala
@@ -1,0 +1,15 @@
+package sauerkraut.format.pb.streams
+
+/** Wire format tags + flags for Protocol buffer encoding. */
+enum WireFormat(val flag: Int):
+  case VarInt extends WireFormat(0)
+  case Fixed32 extends WireFormat(5)
+  case Fixed64 extends WireFormat(1)
+  case LengthDelimited extends WireFormat(2)
+  // Unsupported:
+  // - StartGroup, EndGroup
+
+  // Constructs a proto tag for the wireformat type and the field number.
+  def makeTag(fieldNumber: Int): Int = (fieldNumber << 3) | flag
+  def extractFormat(tag: Int): Int = (tag & 7)
+  def extractField(tag: Int): Int = (tag >>> 3)

--- a/pb/src/main/scala/sauerkraut/format/pb/streams/WireFormat.scala
+++ b/pb/src/main/scala/sauerkraut/format/pb/streams/WireFormat.scala
@@ -11,5 +11,7 @@ enum WireFormat(val flag: Int):
 
   // Constructs a proto tag for the wireformat type and the field number.
   def makeTag(fieldNumber: Int): Int = (fieldNumber << 3) | flag
+
+object WireFormat:
   def extractFormat(tag: Int): Int = (tag & 7)
   def extractField(tag: Int): Int = (tag >>> 3)

--- a/pb/src/main/scala/sauerkraut/format/pb/streams/WireFormat.scala
+++ b/pb/src/main/scala/sauerkraut/format/pb/streams/WireFormat.scala
@@ -14,4 +14,17 @@ enum WireFormat(val flag: Int):
 
 object WireFormat:
   def extractFormat(tag: Int): Int = (tag & 7)
+  def extract(tag: Int): WireFormat =
+    extractFormat(tag) match
+      case 0 => VarInt
+      case 1 => Fixed64
+      case 2 => LengthDelimited
+      case 5 => Fixed32
+      // TODO - good error message
   def extractField(tag: Int): Int = (tag >>> 3)
+
+/** Construct protocol buffer tag-varints for fields. */
+object Tag:
+  inline def apply(format: WireFormat, fieldNumber: Int): Int = format.makeTag(fieldNumber)
+  inline def unapply(tag: Int): (WireFormat, Int) =
+    (WireFormat.extract(tag), WireFormat.extractField(tag))

--- a/pb/src/test/scala/sauerkraut/format/pb/descriptors.scala
+++ b/pb/src/test/scala/sauerkraut/format/pb/descriptors.scala
@@ -33,7 +33,10 @@ case class NestedCollections(
   ints: ArrayBuffer[Long] @field(3)
 ) derives Writer, Buildable, ProtoTypeDescriptor
 
-val MyProtos = Protos[(Nested, Nesting, NestedCollections)]()
+
+case class OneString(message: String @field(1)) derives Writer, Buildable, ProtoTypeDescriptor
+
+val MyProtos = Protos[(Nested, Nesting, NestedCollections, OneString)]()
       
 
 
@@ -51,7 +54,6 @@ class TestProtocolBufferWithDesc:
     val out = java.io.ByteArrayOutputStream()
     pickle(MyProtos).to(out).write(value)
     val bytes = out.toByteArray()
-    System.err.println(s"Pickled:\n${hexString(bytes)}\n\n")
     val in = java.io.ByteArrayInputStream(bytes)
     assertEquals(s"Failed to roundtrip", value, pickle(MyProtos).from(in).read[T])
 
@@ -59,6 +61,7 @@ class TestProtocolBufferWithDesc:
     assertEquals("089601", binaryStringWithDesc(Nesting(150)))
     assertEquals("1a03089601", binaryStringWithDesc(Nested(Nesting(150))))
   @Test def roundTrip(): Unit =
+    roundTrip(OneString("helloo"))
     roundTrip(Nesting(150))
     roundTrip(Nested(Nesting(150)))
     roundTrip(NestedCollections(ArrayBuffer(Nesting(150)), ArrayBuffer(), ArrayBuffer()))

--- a/pb/src/test/scala/sauerkraut/format/pb/raw_compliance.scala
+++ b/pb/src/test/scala/sauerkraut/format/pb/raw_compliance.scala
@@ -3,7 +3,7 @@ package format
 package pb
 
 import java.io.{ByteArrayInputStream,ByteArrayOutputStream}
-import com.google.protobuf.{CodedInputStream,CodedOutputStream}
+
 
 // We only do partial complaince, so we opt-in to what we can do.
 class RawBinaryComplianceTests 

--- a/utils/src/main/scala/sauerkraut/utils/Endian.scala
+++ b/utils/src/main/scala/sauerkraut/utils/Endian.scala
@@ -1,0 +1,9 @@
+package sauerkraut
+package utils
+
+/** An enum representing where most-significant-bit is written in a byte sequence. */
+enum Endian:
+  /** Most significant byte is written first. */
+  case Big
+  /** Least significant byte is written first. */
+  case Little

--- a/utils/src/main/scala/sauerkraut/utils/InlineReader.scala
+++ b/utils/src/main/scala/sauerkraut/utils/InlineReader.scala
@@ -1,0 +1,176 @@
+package sauerkraut
+package utils
+
+import java.io.DataInputStream
+
+/** An exception thrown when UTF encoding is found to be in violation. */
+class UtfEncodingException(msg: String) extends java.io.IOException(msg)
+
+// Helper methods for creating cdoecs/formats.  This should avoid as much JVM-specific code as possible.
+object InlineReader:
+    /** An enum representing where most-significant-bit is written in a byte sequence. */
+  enum Endian:
+    case Big, Little
+  
+  
+  inline def readBoolean(inline readByte: () => Int): Boolean = readByte() != 0
+  inline def readFixed16(inline readByte: () => Int, inline endian: Endian): Short =
+    val b1 = readByte()
+    val b2 = readByte()
+    inline endian match
+      case Endian.Big =>
+        ((b1 << 8) + b2).toShort
+      case Endian.Little =>
+        (b1 + (b2 << 8)).toShort
+  inline def readFixed32(inline readByte: () => Int, inline endian: Endian): Int =
+    val b1 = readByte()
+    val b2 = readByte()
+    val b3 = readByte()
+    val b4 = readByte()
+    inline endian match
+      case Endian.Big =>
+        (b1 << 24) + (b2 << 16)  + (b3 << 8) + b4
+      case Endian.Little =>
+        b1 + (b2 << 8) + (b3 << 16) + (b4 << 24)
+  inline def readFixed64(inline readByte: () => Int, inline endian: Endian): Long =
+    val b1 = readByte()
+    val b2 = readByte()
+    val b3 = readByte()
+    val b4 = readByte()
+    val b5 = readByte()
+    val b6 = readByte()
+    val b7 = readByte()
+    val b8 = readByte()
+    inline endian match
+      case Endian.Big =>
+        (b1.toLong << 56) + 
+        (b2.toLong << 48) + 
+        (b3.toLong << 40) + 
+        (b4.toLong << 32) + 
+        (b5.toLong << 24) + 
+        (b6 << 16)  + 
+        (b7 << 8) + 
+        b8
+      case Endian.Little =>
+        b1 + 
+        (b2 << 8) + 
+        (b3 << 16) + 
+        (b4.toLong << 24) + 
+        (b5.toLong << 32) + 
+        (b6.toLong << 40) + 
+        (b7.toLong << 48) + 
+        (b8.toLong << 56)
+  inline def readFloat(inline readByte: () => Int, inline endian: Endian): Float =
+    java.lang.Float.intBitsToFloat(readFixed32(readByte, endian))
+  inline def readDouble(inline readByte: () => Int, inline endian: Endian): Double =
+    java.lang.Double.longBitsToDouble(readFixed64(readByte, endian))
+
+
+  // Ensure a byte is a UTF-8 continuation byte (i.e. 10xx xxxx)
+  // If it is, then return it without the two-byte header.
+  inline def utf8ContinuationByte(byte: Int): Int =
+    if (byte & 0x80) != 0x80 then
+      throw UtfEncodingException(s"Expected utf continuation byte, found: ${(byte & 0xff).toBinaryString}")
+    else (byte & 0x3f)
+
+  /** 
+   * Given a byte-length and a byte-reader, will decode UTF-8 strings.
+   * 
+   * It expected the byte reader will buffer the length ahead of time for efficiency.
+   */
+  inline def readStringUtf8(length: Int, inline readByte: () => Int): String = 
+    var bytesRead = 0
+    var charCount = 0
+    // TODO - pre-allocate buffer somewhere, or take in a buffering strategy?
+    val buf = new Array[Char](length*2)
+    // First optimise for reading 1-byte characterss
+    var currentByte: Int = 0
+    // Note: Scala while-do is a bit mind-bending when you first appraoch it.
+    // TL;DR the "expression" we use to evaluate whether to continue looping is
+    // a side-effecting expression with early exit.
+    // Here we're just trying to read all characters that fit in one byte.
+    while 
+      // force unsigned values
+      currentByte = readByte() & 0xff
+      bytesRead += 1
+      val simpleCharacter = 
+        if currentByte > 127 then
+          // If we can't run the second loop, then break here.
+          if bytesRead >= length then
+             throw UtfEncodingException(s"Found continuation byte at end of string: ${(currentByte & 0xff).toBinaryString}")
+          else false
+        else
+          buf(charCount) = currentByte.toChar
+          charCount += 1
+          true
+      simpleCharacter && bytesRead < length
+    do ()   
+    // If bytesRead is not == length, then we ran into a unicode character that 
+    // needs more than one byte to represent. NOW we deal with it.
+    // `currentByte` will retain the first part of the higher-order unicode byte.
+    // We need to check its header and determine how many more bytes we need to read, and continue
+    // through the rest of the (likely) unicode string.
+    while
+      bytesRead < length
+    do
+      currentByte >> 4 match
+        // handle two byte character (110xxxxx 10xxxxxx)
+        case 12 | 13 => 
+          // Handle two-byte character
+          val secondByte = utf8ContinuationByte(readByte() & 0xff)
+          buf(charCount) = (
+              ((currentByte & 0x3f) << 6) + 
+              secondByte
+            ).toChar
+          bytesRead += 1
+          charCount += 1
+        // handle three byte character (1110xxxx 10xxxxxx 10xxxxxx)
+        case 14 =>
+          // Handle three byte character
+          val secondByte = utf8ContinuationByte(readByte() & 0xff)
+          val thirdByte = utf8ContinuationByte(readByte() & 0xff)
+          // combine bits in magical ways.
+          buf(charCount) = (
+            ((currentByte & 0x0f) << 12) + 
+            (secondByte << 6) + 
+            thirdByte
+          ).toChar
+          bytesRead += 2
+          charCount += 1
+        // handle four byte character (11110xxx 10xxxxxx 10xxxxxx 10xxxxxx)
+        case 15 =>
+          val firstByte = currentByte & 0xff
+          val secondByte = utf8ContinuationByte(readByte() & 0xff)
+          val thirdByte = utf8ContinuationByte(readByte() & 0xff)
+          val fourthByte = utf8ContinuationByte(readByte() & 0xff)
+          // Grab the integer codepoint.
+          val codePoint = (
+            ((firstByte & 0x07) << 18) +
+            (secondByte  << 12) +
+            (thirdByte << 6) +
+            fourthByte
+          )
+          // Now grab the JVM reprsentation, yay jvm.
+          // TODO - Do we need to check if codepoint size is > 1?
+          buf(charCount) = java.lang.Character.highSurrogate(codePoint)
+          buf(charCount+1) = java.lang.Character.lowSurrogate(codePoint)
+          bytesRead += 3
+          charCount += 2
+        // handle one-byte character
+        case x if x < 7 =>
+          buf(charCount) = currentByte.toChar
+          charCount += 1
+        case _ => 
+          throw UtfEncodingException(s"Encountered invalid byte: ${currentByte.toBinaryString}.  Expected valid UTF header.")
+      // Read next byte and end of do, if we have remaining bytes.
+      if bytesRead < length then
+        currentByte = readByte()
+        bytesRead += 1
+    // Finally create a string from our character buffers.
+    new String(buf, 0, charCount)
+  
+
+  inline def readVarInt64(inline readByte: () => Int): Long =
+    VarInt.readULong(() => readByte().toByte)
+  inline def readVarInt32(inline readByte: () => Int): Int =
+    VarInt.readUInt(() => readByte().toByte)

--- a/utils/src/main/scala/sauerkraut/utils/InlineWriter.scala
+++ b/utils/src/main/scala/sauerkraut/utils/InlineWriter.scala
@@ -1,7 +1,7 @@
 package sauerkraut
 package utils
 
-// Helper methods for creating codecs.
+// Helper methods for creating cdoecs/formats.  This should avoid as much JVM-specific code as possible.
 object InlineWriter:
   final val Utf8 = java.nio.charset.Charset.forName("UTF-8")
   /** An enum representing where most-significant-bit is written in a byte sequence. */

--- a/utils/src/main/scala/sauerkraut/utils/InlineWriter.scala
+++ b/utils/src/main/scala/sauerkraut/utils/InlineWriter.scala
@@ -1,0 +1,80 @@
+package sauerkraut
+package utils
+
+// Helper methods for creating codecs.
+object InlineWriter:
+  final val Utf8 = java.nio.charset.Charset.forName("UTF-8")
+  /** An enum representing where most-significant-bit is written in a byte sequence. */
+  enum Endian:
+    case Big, Little
+
+  /** Writes a boolean value as a single byte, either 0 (false) or 1 (true). */
+  inline def writeBoolean(value: Boolean, inline writeByte: (Byte) => Unit): Unit =
+    writeByte(if value then 1 else 0)
+  /** 
+   * Writes a 16-bit integer value in specified Endian.
+   * 
+   * Note: this must be used to encode `Char` in java, unless using Varint format.
+   */
+  inline def writeFixed16(value: Short, inline writeByte: (Byte) => Unit, inline endian: Endian): Unit =
+    inline endian match
+      case Endian.Big =>
+        writeByte((0xff & (value >> 8)).toByte)
+        writeByte((0xff & value).toByte)
+      case Endian.Little =>
+        writeByte((0xff & value).toByte)
+        writeByte((0xff & (value >> 8)).toByte)
+  /** Writes a 32 bit integer in specified Endian.  That is, the highest byte written first. */
+  inline def writeFixed32(value: Int, inline writeByte: (Byte) => Unit, inline endian: Endian): Unit =
+    inline endian match
+      case Endian.Big =>
+        writeByte((0xff & (value >> 24)).toByte)
+        writeByte((0xff & (value >> 16)).toByte)
+        writeByte((0xff & (value >> 8)).toByte)
+        writeByte((0xff & (value)).toByte)
+      case Endian.Little =>
+        writeByte((0xff & (value)).toByte)
+        writeByte((0xff & (value >> 8)).toByte)
+        writeByte((0xff & (value >> 16)).toByte)
+        writeByte((0xff & (value >> 24)).toByte)
+  /** Writes a 32 bit integer in specified Endian.  That is, the highest byte written first. */
+  inline def writeFixed64(value: Long, inline writeByte: (Byte) => Unit, inline endian: Endian): Unit =
+    inline endian match
+      case Endian.Big =>
+        writeByte((0xff & (value >> 56)).toByte)
+        writeByte((0xff & (value >> 48)).toByte)
+        writeByte((0xff & (value >> 40)).toByte)
+        writeByte((0xff & (value >> 32)).toByte)
+        writeByte((0xff & (value >> 24)).toByte)
+        writeByte((0xff & (value >> 16)).toByte)
+        writeByte((0xff & (value >> 8)).toByte)
+        writeByte((0xff & (value)).toByte)
+      case Endian.Little =>
+        writeByte((0xff & (value)).toByte)
+        writeByte((0xff & (value >> 8)).toByte)
+        writeByte((0xff & (value >> 16)).toByte)
+        writeByte((0xff & (value >> 24)).toByte)
+        writeByte((0xff & (value >> 32)).toByte)
+        writeByte((0xff & (value >> 40)).toByte)
+        writeByte((0xff & (value >> 48)).toByte)
+        writeByte((0xff & (value >> 56)).toByte)
+
+  /** Writes a float to the stream using `Float.floatToIntBits` and fixed32 big endian encoding. */
+  inline def writeFloat(value: Float, inline writeByte: (Byte) => Unit, inline endian: Endian): Unit = writeFixed32(java.lang.Float.floatToIntBits(value), writeByte, endian)
+  /** Writes a Double to the stream using `Double.doubleToIntBits` and fixed32 big endian encoding. */
+  inline def writeDouble(value: Double, inline writeByte: (Byte) => Unit, inline endian: Endian): Unit = writeFixed64(java.lang.Double.doubleToLongBits(value), writeByte, endian)
+
+  /**
+    * Writes the given integer value as a "varint".  In this format, the MSB represent whether or not more bytes should be read or not.
+    * 
+    * In this implementation, negative integers are FIRST cast to unsigned Long, then written, meaning they take ~10 bytes instead of 5.
+    */
+  inline def writeVarInt32(value: Int, inline writeByte: (Byte) => Unit): Unit = VarInt.writeUInt(value, writeByte)
+  /**
+    * Writes the given integer value as a "varint".  In this format, the MSB represent whether or not more bytes should be read or not.
+    * 
+    * All signed values are converted to unsigned before encoding.
+    */
+  inline def writeVarInt64(value: Long, inline writeByte: (Byte) => Unit): Unit = VarInt.writeULong(value, writeByte)
+  /** Writes a string as UTF-8 encoded bytes. */
+  inline def writeStringUtf8(value: String, inline writeBytes: (Array[Byte]) => Unit): Unit = writeBytes(value.getBytes(Utf8))

--- a/utils/src/main/scala/sauerkraut/utils/InlineWriter.scala
+++ b/utils/src/main/scala/sauerkraut/utils/InlineWriter.scala
@@ -1,20 +1,30 @@
 package sauerkraut
 package utils
 
-// Helper methods for creating cdoecs/formats.  This should avoid as much JVM-specific code as possible.
+/**
+  * Helper methods for creating cdoecs/formats.
+  * 
+  * This should avoid as much JVM-specific code as possible, over time.
+  */
 object InlineWriter:
-  final val Utf8 = java.nio.charset.Charset.forName("UTF-8")
-  /** An enum representing where most-significant-bit is written in a byte sequence. */
-  enum Endian:
-    case Big, Little
+  inline def Utf8 = java.nio.charset.StandardCharsets.UTF_8
 
-  /** Writes a boolean value as a single byte, either 0 (false) or 1 (true). */
+  /** 
+   * Writes a boolean value as a single byte, either 0 (false) or 1 (true). 
+   * 
+   * @param value The boolean value to encode.
+   * @param writeByte A function to write a byte into an output.  It is expected this function will throw exceptions.
+   */
   inline def writeBoolean(value: Boolean, inline writeByte: (Byte) => Unit): Unit =
     writeByte(if value then 1 else 0)
   /** 
    * Writes a 16-bit integer value in specified Endian.
    * 
    * Note: this must be used to encode `Char` in java, unless using Varint format.
+   *
+   * @param value The integer value to encode. 
+   * @param writeByte A function to write a byte into an output.  It is expected this function will throw exceptions.
+   * @param endian Either Big or Little.  Big = highest byte written first, Little = smallest byte written first. 
    */
   inline def writeFixed16(value: Short, inline writeByte: (Byte) => Unit, inline endian: Endian): Unit =
     inline endian match
@@ -24,7 +34,14 @@ object InlineWriter:
       case Endian.Little =>
         writeByte((0xff & value).toByte)
         writeByte((0xff & (value >> 8)).toByte)
-  /** Writes a 32 bit integer in specified Endian.  That is, the highest byte written first. */
+
+  /** 
+   * Writes a 32 bit integer in specified Endian.
+   * 
+   * @param value The integer value to encode. 
+   * @param writeByte A function to write a byte into an output.  It is expected this function will throw exceptions.
+   * @param endian Either Big or Little.  Big = highest byte written first, Little = smallest byte written first. 
+   */
   inline def writeFixed32(value: Int, inline writeByte: (Byte) => Unit, inline endian: Endian): Unit =
     inline endian match
       case Endian.Big =>
@@ -37,7 +54,13 @@ object InlineWriter:
         writeByte((0xff & (value >> 8)).toByte)
         writeByte((0xff & (value >> 16)).toByte)
         writeByte((0xff & (value >> 24)).toByte)
-  /** Writes a 32 bit integer in specified Endian.  That is, the highest byte written first. */
+  /** 
+   * Writes a 32 bit integer in specified Endian.  
+   * 
+   * @param value The integer value to encode. 
+   * @param writeByte A function to write a byte into an output.  It is expected this function will throw exceptions.
+   * @param endian Either Big or Little.  Big = highest byte written first, Little = smallest byte written first. 
+   */
   inline def writeFixed64(value: Long, inline writeByte: (Byte) => Unit, inline endian: Endian): Unit =
     inline endian match
       case Endian.Big =>
@@ -59,22 +82,53 @@ object InlineWriter:
         writeByte((0xff & (value >> 48)).toByte)
         writeByte((0xff & (value >> 56)).toByte)
 
-  /** Writes a float to the stream using `Float.floatToIntBits` and fixed32 big endian encoding. */
-  inline def writeFloat(value: Float, inline writeByte: (Byte) => Unit, inline endian: Endian): Unit = writeFixed32(java.lang.Float.floatToIntBits(value), writeByte, endian)
-  /** Writes a Double to the stream using `Double.doubleToIntBits` and fixed32 big endian encoding. */
-  inline def writeDouble(value: Double, inline writeByte: (Byte) => Unit, inline endian: Endian): Unit = writeFixed64(java.lang.Double.doubleToLongBits(value), writeByte, endian)
+  /** 
+   * Writes a float to the stream using `Float.floatToIntBits` and fixed32 big endian encoding.
+   * 
+   * Note: This method currently relies on the JVM intrinsic `java.lang.Float.floatToIntBits`, then writes out the integer.
+   * 
+   * @param value A floating point value
+   * @param writeByte A function to write a byte into an output.  It is expected this function will throw exceptions.
+   * @param endian Either Big or Little.  Big = highest byte written first, Little = smallest byte written first. 
+   */
+  inline def writeFloat(value: Float, inline writeByte: (Byte) => Unit, inline endian: Endian): Unit =
+    writeFixed32(java.lang.Float.floatToIntBits(value), writeByte, endian)
+
+  /** 
+   * Writes a Double to the stream using `Double.doubleToIntBits` and fixed32 big endian encoding. 
+   * 
+   * Note: This method currently relies on the JVM intrinsic `java.lang.Double.doubleToLongBits`, then writes out the integer.
+   * 
+   * @param value A floating point value
+   * @param writeByte A function to write a byte into an output.  It is expected this function will throw exceptions.
+   * @param endian Either Big or Little.  Big = highest byte written first, Little = smallest byte written first. 
+   */
+  inline def writeDouble(value: Double, inline writeByte: (Byte) => Unit, inline endian: Endian): Unit =
+    writeFixed64(java.lang.Double.doubleToLongBits(value), writeByte, endian)
 
   /**
     * Writes the given integer value as a "varint".  In this format, the MSB represent whether or not more bytes should be read or not.
     * 
     * In this implementation, negative integers are FIRST cast to unsigned Long, then written, meaning they take ~10 bytes instead of 5.
+    * 
+    * @param writeByte A function to write a byte into an output.  It is expected this function will throw exceptions.
     */
-  inline def writeVarInt32(value: Int, inline writeByte: (Byte) => Unit): Unit = VarInt.writeUInt(value, writeByte)
+  inline def writeVarInt32(value: Int, inline writeByte: (Byte) => Unit): Unit =
+    VarInt.writeUInt(value, writeByte)
+
   /**
     * Writes the given integer value as a "varint".  In this format, the MSB represent whether or not more bytes should be read or not.
     * 
     * All signed values are converted to unsigned before encoding.
     */
-  inline def writeVarInt64(value: Long, inline writeByte: (Byte) => Unit): Unit = VarInt.writeULong(value, writeByte)
-  /** Writes a string as UTF-8 encoded bytes. */
-  inline def writeStringUtf8(value: String, inline writeBytes: (Array[Byte]) => Unit): Unit = writeBytes(value.getBytes(Utf8))
+  inline def writeVarInt64(value: Long, inline writeByte: (Byte) => Unit): Unit =
+    VarInt.writeULong(value, writeByte)
+
+  /** 
+   * Writes a string as UTF-8 encoded bytes. 
+   * 
+   * @param value the String to be converted into UTF-8 byte array.  If it is already a UTF-8 byte array, this should be a noop.
+   * @param writeBytes A function to write a byte array into an output.  It is expected this function will throw exceptions and buffer appropriately.
+   */
+  inline def writeStringUtf8(value: String, inline writeBytes: (Array[Byte]) => Unit): Unit =
+    writeBytes(value.getBytes(Utf8))

--- a/utils/src/main/scala/sauerkraut/utils/VarInt.scala
+++ b/utils/src/main/scala/sauerkraut/utils/VarInt.scala
@@ -32,7 +32,7 @@ object VarInt:
 
   // Helper methods / inline impls.
 
-  private inline def readULong(inline readNext: () => Byte): Long =
+  inline def readULong(inline readNext: () => Byte): Long =
     var currentByte: Byte = readNext()
     if (currentByte & 0x80) == 0 then currentByte.toLong
     else
@@ -45,7 +45,7 @@ object VarInt:
         (currentByte & 0x80) != 0 // && offset < 64 
       do ()
       result
-  private inline def readUInt(inline readNext: () => Byte): Int =
+  inline def readUInt(inline readNext: () => Byte): Int =
     var currentByte: Byte = readNext()
     if (currentByte & 0x80) == 0 then currentByte.toInt
     else

--- a/utils/src/main/scala/sauerkraut/utils/VarInt.scala
+++ b/utils/src/main/scala/sauerkraut/utils/VarInt.scala
@@ -59,7 +59,13 @@ object VarInt:
         result |= (currentByte & 0x7f) << offset
         (currentByte & 0x80 ) != 0 && offset < 32
       do ()
-      // TODO - if we encode negative ints as 64-bit VarInts, keep reading those bytes
+      // If we encode negative ints as 64-bit VarInts, keep reading those bytes.  This keeps us compatible
+      // with proto buff.
+      while
+          (currentByte & 0x80) != 0 && offset < 64
+      do
+        offset += 7 
+        currentByte = readNext()
       result
 
 

--- a/utils/src/main/scala/sauerkraut/utils/VarInt.scala
+++ b/utils/src/main/scala/sauerkraut/utils/VarInt.scala
@@ -1,0 +1,88 @@
+package sauerkraut
+package utils
+
+/**
+  * Helper for writing variable-sized integers
+  */
+object VarInt:
+  /** Returns the size, in bytes, a varint will take when written. */
+  def byteSize(value: Int): Int = varIntLength(value)+1
+  /** Returns the size, in bytes, a varint will take when written. */
+  def byteSize(value: Long): Int = varIntLength(value)+1
+
+  /** Reads an Int32 from a byte buffer.  Note:  Negative values are encoded as UInt64, and interpreted. */
+  def readInt(buffer: java.nio.ByteBuffer): Int = readUInt(buffer.get)
+  /** Reads a varint (of max 64 bits) from the given byte buffer. */
+  def readLong(buffer: java.nio.ByteBuffer): Long = readULong(buffer.get)
+
+  /** Reads an Int32 from a byte buffer.  Note:  Negative values are encoded as UInt64, and interpreted. */
+  def readInt(in: java.io.InputStream): Int = readUInt(() => in.read().toByte)
+  /** Reads a varint (of max 64 bits) from the given byte buffer. */
+  def readLong(in: java.io.InputStream): Long = readULong(() => in.read().toByte)
+
+  /** Writes a varint to a byte buffer. */
+  def write(value: Int, buffer: java.nio.ByteBuffer): Unit = writeUInt(value, buffer.put)
+  /** Writes a varint to a byte buffer. */
+  def write(value: Long, buffer: java.nio.ByteBuffer): Unit = writeULong(value, buffer.put)
+
+  /** Writes a varint to a byte buffer. */
+  def write(value: Int, out: java.io.OutputStream): Unit = writeUInt(value, out.write)
+  /** Writes a varint to a byte buffer. */
+  def write(value: Long, out: java.io.OutputStream): Unit = writeULong(value, out.write)
+
+  // Helper methods / inline impls.
+
+  private inline def readULong(inline readNext: () => Byte): Long =
+    var currentByte: Byte = readNext()
+    if (currentByte & 0x80) == 0 then currentByte.toLong
+    else
+      var result: Long = currentByte & 0x7f
+      var offset = 0
+      while
+        offset += 7
+        currentByte = readNext()
+        result |= (currentByte & 0x7F).toLong << offset
+        (currentByte & 0x80) != 0 // && offset < 64 
+      do ()
+      result
+  private inline def readUInt(inline readNext: () => Byte): Int =
+    var currentByte: Byte = readNext()
+    if (currentByte & 0x80) == 0 then currentByte.toInt
+    else
+      var result: Int = currentByte & 0x7F
+      var offset: Int = 0
+      // Loop over bytes, pulling off MSB and shifting until we have all our bits.
+      // TODO - unroll this for INT32 size?
+      while
+        offset += 7
+        currentByte = readNext()
+        result |= (currentByte & 0x7f) << offset
+        (currentByte & 0x80 ) != 0 && offset < 32
+      do ()
+      // TODO - if we encode negative ints as 64-bit VarInts, keep reading those bytes
+      result
+
+
+  // Note we use leading-zero optimisations as described here:
+  // https://richardstartin.github.io/posts/dont-use-protobuf-for-telemetry
+  private val VarIntLengths = (for (i <- 0 to 64) yield (63-i)/7).toArray
+  private def varIntLength(value: Long): Int = VarIntLengths(java.lang.Long.numberOfLeadingZeros(value))
+  inline def writeUInt(value: Int, inline writeByte: Byte => Unit): Unit =
+    val length = varIntLength(value)
+    var shiftedValue = value
+    var i = 0
+    while i < length do
+      writeByte(((shiftedValue & 0x7F) | 0x80).toByte)
+      shiftedValue >>>=7
+      i += 1
+    writeByte(shiftedValue.toByte)
+
+  inline def writeULong(value: Long, inline writeByte: Byte => Unit): Unit =
+    val length = varIntLength(value)
+    var shiftedValue = value
+    var i = 0
+    while i < length do
+      writeByte(((shiftedValue & 0x7F) | 0x80).toByte)
+      shiftedValue >>>=7
+      i += 1
+    writeByte(shiftedValue.toByte)

--- a/utils/src/test/scala/sauerkraut/utils/TestInlineUtils.scala
+++ b/utils/src/test/scala/sauerkraut/utils/TestInlineUtils.scala
@@ -1,0 +1,158 @@
+package sauerkraut
+package utils
+
+import org.junit.{Test, Assert}
+
+class OutputHelper(output: Array[Byte]):
+  var position: Int = 0
+  inline def writeByte(byte: Byte): Unit =
+    output(position) = byte
+    position += 1
+  def writeBoolean(value: Boolean): Unit =
+    InlineWriter.writeBoolean(value, (x) => writeByte(x))
+  def writeShortBE(value: Short): Unit =
+    InlineWriter.writeFixed16(value, (x) => writeByte(x), InlineWriter.Endian.Big)
+  def writeShortLE(value: Short): Unit =
+    InlineWriter.writeFixed16(value, (x) => writeByte(x), InlineWriter.Endian.Little)
+  def writeIntBE(value: Int): Unit =
+    InlineWriter.writeFixed32(value, (x) => writeByte(x), InlineWriter.Endian.Big)
+  def writeIntLE(value: Int): Unit =
+    InlineWriter.writeFixed32(value, (x) => writeByte(x), InlineWriter.Endian.Little)
+  def writeLongBE(value: Long): Unit =
+    InlineWriter.writeFixed64(value, (x) => writeByte(x), InlineWriter.Endian.Big)
+  def writeLongLE(value: Long): Unit =
+    InlineWriter.writeFixed64(value, (x) => writeByte(x), InlineWriter.Endian.Little)
+  def writeFloatBE(value: Float): Unit =
+    InlineWriter.writeFloat(value, (x) => writeByte(x), InlineWriter.Endian.Big)
+  def writeFloatLE(value: Float): Unit =
+    InlineWriter.writeFloat(value, (x) => writeByte(x), InlineWriter.Endian.Little)
+  def writeDoubleBE(value: Double): Unit =
+    InlineWriter.writeDouble(value, (x) => writeByte(x), InlineWriter.Endian.Big)
+  def writeDoubleLE(value: Double): Unit =
+    InlineWriter.writeDouble(value, (x) => writeByte(x), InlineWriter.Endian.Little)
+  def writeStringUtf8(value: String): Unit =
+    InlineWriter.writeStringUtf8(value, (x: Array[Byte]) => System.arraycopy(x, 0, output, position, x.length))
+  
+
+class InputHelper(input: Array[Byte]):
+  var position: Int = 0
+  inline def readByte(): Int =
+    val result = input(position)
+    position += 1
+    result
+
+  def readStringUtf8(length: Int): String =
+    InlineReader.readStringUtf8(length, () => readByte())
+
+class TestInlineUtils:
+  @Test def testWriteBoolean(): Unit =
+    val buf = new Array[Byte](2)
+    OutputHelper(buf).writeBoolean(true)
+    Assert.assertEquals(Seq[Byte](1, 0), buf.toSeq)
+    OutputHelper(buf).writeBoolean(false)
+    Assert.assertEquals(Seq[Byte](0, 0), buf.toSeq)
+
+  @Test def testWriteShort(): Unit = 
+    val buf = new Array[Byte](2)
+    OutputHelper(buf).writeShortBE(1)
+    Assert.assertEquals(Seq[Byte](0, 1), buf.toSeq)
+    OutputHelper(buf).writeShortLE(1)
+    Assert.assertEquals(Seq[Byte](1, 0), buf.toSeq)
+
+  @Test def testWriteInt(): Unit =
+    val buf = new Array[Byte](4)
+    OutputHelper(buf).writeIntBE(1)
+    Assert.assertEquals(Seq[Byte](0, 0, 0, 1), buf.toSeq)
+    OutputHelper(buf).writeIntLE(1)
+    Assert.assertEquals(Seq[Byte](1, 0, 0, 0), buf.toSeq)
+
+  @Test def testWriteLong(): Unit =
+    val buf = new Array[Byte](8)
+    OutputHelper(buf).writeLongBE(1)
+    Assert.assertEquals(Seq[Byte](0, 0, 0, 0, 0, 0, 0, 1), buf.toSeq)
+    OutputHelper(buf).writeLongLE(1)
+    Assert.assertEquals(Seq[Byte](1, 0, 0, 0, 0, 0, 0, 0), buf.toSeq)
+
+  @Test def testWriteFloat(): Unit =
+    val buf = new Array[Byte](4)
+    // TODO - write spec for IEEE floating point layout here...
+    OutputHelper(buf).writeFloatBE(1.0)
+    Assert.assertEquals(Seq[Byte](63, -128, 0, 0), buf.toSeq)
+    OutputHelper(buf).writeFloatBE(-2.123e24)
+    Assert.assertEquals(Seq[Byte](-25, -32, -56, 8), buf.toSeq)
+    OutputHelper(buf).writeFloatLE(1.0)
+    Assert.assertEquals(Seq[Byte](0, 0, -128, 63), buf.toSeq)
+    OutputHelper(buf).writeFloatLE(-2.123e24)
+    Assert.assertEquals(Seq[Byte](8, -56, -32, -25), buf.toSeq)
+
+  @Test def testWriteDouble(): Unit =
+    val buf = new Array[Byte](8)
+    OutputHelper(buf).writeDoubleBE(1.0)
+    // TODO - write spec for IEEE floating point layout here...
+    Assert.assertEquals(Seq[Byte](63, -16, 0, 0, 0, 0, 0, 0), buf.toSeq)
+    OutputHelper(buf).writeDoubleBE(-2.123e24)
+    Assert.assertEquals(Seq[Byte](-60, -4, 25, 0, -8, 65, 126, -44), buf.toSeq)
+    OutputHelper(buf).writeDoubleLE(1.0)
+    Assert.assertEquals(Seq[Byte](0, 0, 0, 0, 0, 0, -16, 63), buf.toSeq)
+    OutputHelper(buf).writeDoubleLE(-2.123e24)
+    Assert.assertEquals(Seq[Byte](-44, 126, 65, -8, 0, 25, -4, -60), buf.toSeq)
+
+
+  @Test def testWriteStringUtf8(): Unit =
+    val testString = "hello you guys"
+    val length = testString.getBytes(InlineWriter.Utf8).length
+    val buf = new Array[Byte](length)
+    OutputHelper(buf).writeStringUtf8(testString)
+    Assert.assertEquals(Seq[Byte](
+      'h'.toByte,
+      'e'.toByte,
+      'l'.toByte,
+      'l'.toByte,
+      'o'.toByte,
+      ' '.toByte,
+      'y'.toByte,
+      'o'.toByte,
+      'u'.toByte,
+      ' '.toByte,
+      'g'.toByte,
+      'u'.toByte,
+      'y'.toByte,
+      's'.toByte), buf.toSeq)
+  // TODO - test an odd encoded character (something with a highpoint, like the eurosign.)
+
+  @Test def testReadSimpleStringUtf8(): Unit =
+    val testString = "hello you guys"
+    val bytes = testString.getBytes(InlineWriter.Utf8)
+    Assert.assertEquals(bytes.length, 14)
+    Assert.assertEquals(testString, InputHelper(bytes).readStringUtf8(14))
+
+
+  @Test def testReadTwoByteInStringUtf8(): Unit =
+    val testString = "10¢"
+    val bytes = testString.getBytes(InlineWriter.Utf8)
+    Assert.assertEquals(bytes.length, 4)
+    Assert.assertEquals(testString.size, 3)
+    val result = InputHelper(bytes).readStringUtf8(4)
+    Assert.assertEquals(testString(2).toInt, result(2).toInt)
+    Assert.assertEquals(testString, result)
+
+  @Test def testReadThreeByteInStringUtf8(): Unit =
+    val testString = "10€"
+    val bytes = testString.getBytes(InlineWriter.Utf8)
+    Assert.assertEquals(5, bytes.length)
+    Assert.assertEquals(3, testString.size)
+    val result = InputHelper(bytes).readStringUtf8(5)
+    Assert.assertEquals(testString(2).toInt, result(2).toInt)
+    Assert.assertEquals(testString, result)
+
+  @Test def testReadFourByteInStringUtf8(): Unit =
+    val testString = "10𐍈"
+    val bytes = testString.getBytes(InlineWriter.Utf8)
+    Assert.assertEquals("We understand unicode", 66376, java.lang.Character.codePointAt(testString.toCharArray, 2))
+    Assert.assertEquals(6, bytes.length)
+    Assert.assertEquals(4, testString.size)
+    val result = InputHelper(bytes).readStringUtf8(5)
+    Assert.assertEquals("First two-part unicode character is right", testString(2).toInt, result(2).toInt)
+    Assert.assertEquals("Secoond two-part unicode character is right", testString(3).toInt, result(3).toInt)
+    Assert.assertEquals(testString, result)
+    

--- a/utils/src/test/scala/sauerkraut/utils/TestVarInt.scala
+++ b/utils/src/test/scala/sauerkraut/utils/TestVarInt.scala
@@ -1,0 +1,148 @@
+package sauerkraut
+package utils
+
+import com.google.protobuf.{CodedOutputStream, CodedInputStream}
+import org.junit.Test
+import org.junit.Assert._
+
+def hexString(buf: Array[Byte]): String =
+  buf.map(b => f"$b%02x").mkString("")
+
+
+class TestVarInt:
+  val buf = java.nio.ByteBuffer.allocate(32)
+
+  
+  def writeIntToHexString(value: Int): String =
+    buf.clear()
+    VarInt.write(value, buf)
+    buf.flip()
+    val length = buf.remaining()
+    val nextBuf = new Array[Byte](length)
+    buf.get(nextBuf)
+    hexString(nextBuf)
+
+  def writeLongToHexString(value: Long): String =
+    buf.clear()
+    VarInt.write(value, buf)
+    buf.flip()
+    val length = buf.remaining()
+    val nextBuf = new Array[Byte](length)
+    buf.get(nextBuf)
+    hexString(nextBuf)
+
+  def writeThenReadInt(value: Int): Int =
+    buf.clear()
+    VarInt.write(value, buf)
+    buf.flip()
+    VarInt.readInt(buf)
+
+  def writeThenReadLong(value: Long): Long =
+    buf.clear()
+    VarInt.write(value, buf)
+    buf.flip()
+    VarInt.readLong(buf)
+
+  def writeProtoThenReadLong(value: Long): Long =
+    buf.clear()
+    val out = CodedOutputStream.newInstance(buf)
+    out.writeUInt64NoTag(value)
+    out.flush()
+    buf.flip()
+    VarInt.readLong(buf)
+
+
+  def writeProtoThenReadInt(value: Int): Int =
+    buf.clear()
+    val out = CodedOutputStream.newInstance(buf)
+    out.writeUInt32NoTag(value)
+    out.flush()
+    buf.flip()
+    VarInt.readInt(buf)
+
+  def writeThenReadProtoInt(value: Int): Int =
+    buf.clear()
+    VarInt.write(value, buf)
+    buf.flip()
+    val in = CodedInputStream.newInstance(buf)
+    in.readRawVarint32()
+
+  def writeThenReadProtoLong(value: Long): Long =
+    buf.clear()
+    VarInt.write(value, buf)
+    buf.flip()
+    val in = CodedInputStream.newInstance(buf)
+    in.readRawVarint64()
+
+  @Test
+  def testInt32Size(): Unit =
+    assertEquals("Size of 1", 1, VarInt.byteSize(1))
+    assertEquals("Size of 0", 1, VarInt.byteSize(0))
+    assertEquals("Size of 256", 2, VarInt.byteSize(256))
+    assertEquals("Size of 1048576", 3, VarInt.byteSize(1048576))
+    assertEquals("Size of 111048576", 4, VarInt.byteSize(111048576))
+    assertEquals("Size of Int.MaxValue", 5, VarInt.byteSize(Int.MaxValue))
+    // Negative integers get converted to Uint64 for encoding
+    assertEquals("Size of Int.MinValue", 10, VarInt.byteSize(Int.MinValue))
+    assertEquals("Size of -1", 10, VarInt.byteSize(-1))
+
+  @Test
+  def testWriteInt32(): Unit =
+    assertEquals("Writes value 1", "01", writeIntToHexString(1))
+    assertEquals("Writes value 0", "00", writeIntToHexString(0))
+    assertEquals("Writes value 256", "8002", writeIntToHexString(256))
+    assertEquals("Writes value 1048576", "808040", writeIntToHexString(1048576))
+    assertEquals("Writes value 111048576", "80eff934", writeIntToHexString(111048576))
+    assertEquals("Writes value Int.MaxValue", "ffffffff07", writeIntToHexString(Int.MaxValue))
+    // Negative integer values get converted into UInt64 for encoding.
+    assertEquals("Writes value Int.MinValue", "80808080888080808000", writeIntToHexString(Int.MinValue))
+    assertEquals("Writes value -1", "ffffffff8f8080808000", writeIntToHexString(-1))
+  
+  @Test
+  def testInt64Size(): Unit =
+    assertEquals("Size of 1", 1, VarInt.byteSize(1L))
+    assertEquals("Size of 0", 1, VarInt.byteSize(0L))
+    assertEquals("Size of 256", 2, VarInt.byteSize(256L))
+    assertEquals("Size of 1048576", 3, VarInt.byteSize(1048576L))
+    assertEquals("Size of 111048576", 4, VarInt.byteSize(111048576L))
+    assertEquals("Size of Long.MaxValue", 9, VarInt.byteSize(Long.MaxValue))
+    assertEquals("Size of Long.MinValue", 10, VarInt.byteSize(Long.MinValue))
+    assertEquals("Size of -1", 10, VarInt.byteSize(-1L))
+
+  @Test
+  def testWriteInt64(): Unit =
+    // Signed values encode the same as `Int`/Int32
+    assertEquals("Writes value 1", "01", writeLongToHexString(1L))
+    assertEquals("Writes value 0", "00", writeLongToHexString(0L))
+    assertEquals("Writes value 256", "8002", writeLongToHexString(256L))
+    assertEquals("Writes value 1048576", "808040", writeLongToHexString(1048576L))
+    assertEquals("Writes value 111048576", "80eff934", writeLongToHexString(111048576L)) 
+    // Is this correct encoding of negatives? we treat them as unsigned Long
+    assertEquals("Writes value -1", "ffffffffffffffffff01", writeLongToHexString(-1L))
+    assertEquals("Writes value Long.Max", "ffffffffffffffff7f", writeLongToHexString(Long.MaxValue))
+
+  private val InterestingInts = Seq(1, 0, 256, 11048576, Int.MaxValue, -1, Int.MinValue)
+  
+  @Test def testWriteThenReadInt32(): Unit =
+    for value <- InterestingInts
+    do
+      assertEquals(s"Reads a written int of $value", value, writeThenReadInt(value))
+
+  @Test def compatibleWithProtoInt32(): Unit =
+    for value <- InterestingInts
+    do
+      assertEquals(s"Reads a varint32 written by proto", value, writeProtoThenReadInt(value))
+      assertEquals(s"Proto reads a varint32 written by us", value, writeThenReadProtoInt(value))
+
+  private val InterestingLongs = Seq(1L, 0L, 256L, 11048576L, Long.MaxValue, -1L, Long.MinValue)
+
+  @Test def testWriteThenReadInt64(): Unit =
+    for value <- InterestingLongs
+    do
+      assertEquals(s"Reads a written long of $value", value, writeThenReadLong(value))
+  
+  @Test def compatibleWithProtoInt64(): Unit =
+    for value <- InterestingLongs
+    do
+      assertEquals(s"Reads a varint32 written by proto", value, writeProtoThenReadLong(value))
+      assertEquals(s"Proto reads a varint32 written by us", value, writeThenReadProtoLong(value))


### PR DESCRIPTION
- Remove ProtocolBuffer dependency from proto encoding
- Try to avoid more JVM-specific-isms in core serialization code (maybe one day we'll Scala-JS this)
- Add a feature-full (but maybe not yet robust) set of utilties for defining byte-shuffling codecs
- Replace NbtWriter + Proto In/Out with custom implementations.